### PR TITLE
Fix #125: Updated django-allauth to latest version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ diff-match-patch==20121119
 dj-database-url==0.4.0
 Django==1.9.2
 django-activity-stream==0.6.3
-django-allauth==0.27.0
+django-allauth==0.32.0
 django-cors-headers==1.1.0
 django-email-obfuscator==0.1.4
 django-gravatar2==1.4.0


### PR DESCRIPTION
The existing django-allauth (version: 0.27.0) was having an issue due to which `django.contrib.auth.password_validation.UserAttributeSimilarityValidator` was not working on registration. The latest version for django-allauth (version 0.32.0) fixes this problem. Fixes #125.