### PR TITLE
Fix #172: Added media query to manipulate font size for featured website title.

### DIFF
--- a/website/static/css/sb-admin-2.css
+++ b/website/static/css/sb-admin-2.css
@@ -247,6 +247,11 @@ table.dataTable thead .sorting:after {
 .huge {
   font-size: 40px;
 }
+@media (max-width: 414px) {
+  .huge {
+    font-size: 25px;
+  }
+}
 .panel-green {
   border-color: #5cb85c;
 }


### PR DESCRIPTION
Added media queries which sets the font size for featured website's title to 25px for width less than 414px.