### PR TITLE
Added number of comments per issues on issue page

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -457,4 +457,4 @@ input[type='file'] {
  	position:absolute;
  	bottom:10px;
  	left:500px;
-}
+ }

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -453,3 +453,8 @@ input[type='file'] {
 	position: absolute;
 	right: 20px;
 }
+.comment_link {
+ 	position:absolute;
+ 	bottom:10px;
+ 	left:500px;
+}

--- a/website/templates/_activity.html
+++ b/website/templates/_activity.html
@@ -1,7 +1,7 @@
 {% load gravatar %}
 <div class="list-group-item activity-strip">
     <div class="activity-strip-section">
-    <a  class="comment_link" href="{{activity.target.get_absolute_url }}#comments_form">{{ activity.target.comments.all|length }} comments</a>
+    <a class="comment_link" href="{{activity.target.get_absolute_url }}#comments_form">{{ activity.target.comments.all|length }} comments</a>
 
         {% if activity.actor.socialaccount_set.all.0.get_avatar_url %}
             <img src="{{activity.actor.socialaccount_set.all.0.get_avatar_url}}" width="100" class="img-responsive img-rounded">

--- a/website/templates/_activity.html
+++ b/website/templates/_activity.html
@@ -1,6 +1,7 @@
 {% load gravatar %}
 <div class="list-group-item activity-strip">
     <div class="activity-strip-section">
+    <a  class="comment_link" href="{{activity.target.get_absolute_url }}#comments_form">{{ activity.target.comments.all|length }} comments</a>
 
         {% if activity.actor.socialaccount_set.all.0.get_avatar_url %}
             <img src="{{activity.actor.socialaccount_set.all.0.get_avatar_url}}" width="100" class="img-responsive img-rounded">

--- a/website/templates/domain.html
+++ b/website/templates/domain.html
@@ -124,7 +124,7 @@
                                         <em>{{ activity.created|timesince }} ago</em>
                                     </span>
 
-                                     <a  class="comment_link" href="{{activity.get_absolute_url }}#comments_form">
+                                     <a class="comment_link" href="{{activity.get_absolute_url }}#comments_form">
                                          {{ activity.comments.all|length  }} comments
                                      </a>
 

--- a/website/templates/domain.html
+++ b/website/templates/domain.html
@@ -123,6 +123,11 @@
                                     <span class="text-muted small">
                                         <em>{{ activity.created|timesince }} ago</em>
                                     </span>
+
+                                     <a  class="comment_link" href="{{activity.get_absolute_url }}#comments_form">
+                                         {{ activity.comments.all|length  }} comments
+                                     </a>
+
                                     {% if activity.screenshot %}
                                         <a href="{{ activity.get_absolute_url }}">
                                             <img src="{{ activity.screenshot.url }}" class="img-responsive screenshot-image">

--- a/website/templates/issue.html
+++ b/website/templates/issue.html
@@ -178,7 +178,7 @@
     {% endif %}
 </div>
 
-<form method="post" action="{% url 'comments.views.AddComment' pk=issue.pk %}">
+<form method="post" action="{% url 'comments.views.AddComment' pk=issue.pk %}" id="comments_form">
     {% csrf_token %}
     <div class="form-group">
         <textarea placeholder="Comment" class="form-control" name="text_comment" required></textarea>


### PR DESCRIPTION
Now the issues page would include the number of comments on each issues ,and clicking on each link would lead to the respective issue.
![screenshot from 2017-06-15 21 57 44](https://user-images.githubusercontent.com/16963976/27191543-af3c72e2-5215-11e7-84a7-b936233ec239.png)
 