### PR TITLE
Fix #730, captcha on report page

### DIFF
--- a/website/models.py
+++ b/website/models.py
@@ -20,7 +20,7 @@ from django.dispatch import receiver
 from rest_framework.authtoken.models import Token
 from mdeditor.fields import MDTextField
 from decimal import Decimal
-
+from captcha.fields import CaptchaField
 
 @receiver(post_save, sender=settings.AUTH_USER_MODEL)
 def create_auth_token(sender, instance=None, created=False, **kwargs):
@@ -193,6 +193,7 @@ class Issue(models.Model):
     domain = models.ForeignKey(Domain, null=True, blank=True, on_delete=models.CASCADE)
     url = models.URLField()
     description = models.TextField()
+    captcha = CaptchaField()
     label = models.PositiveSmallIntegerField(choices=labels, default=0)
     views = models.IntegerField(null=True, blank=True)
     verified = models.BooleanField(default=False)

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -161,6 +161,8 @@
                                                                           class="badge badge-important"></span></center>
                                                         </span>
                                         </div>
+                                        {% csrf_token %}
+                                        {{ captcha_form.captcha }}
                                         <div class="bottom text-center">
                                             <button type="submit" class="btn btn-default">{% trans "Report Bug" %} <i
                                                     class="fa fa-trophy" aria-hidden="true">+3</i></button>

--- a/website/templates/report.html
+++ b/website/templates/report.html
@@ -90,10 +90,13 @@
                 </span>
                         {% endif %}
                     </div>
+                    {% csrf_token %}
+                    {{ captcha_form.captcha }}
                     <button type="submit" name="reportbug_button" id="btn" class="btn btn-default btn-block"
                             data-intro="Click here to report the bug to BugHeist." data-step="5">
                         Report Bug <i class="fa fa-trophy" aria-hidden="true">+3</i>
                     </button>
+
             </div>
     </form>
     <script type="text/javascript">

--- a/website/views.py
+++ b/website/views.py
@@ -580,6 +580,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
     def get_context_data(self, **kwargs):
         context = super(IssueCreate, self).get_context_data(**kwargs)
         context["activities"] = Issue.objects.all()[0:10]
+        context["captcha_form"] = CaptchaForm()
         if self.request.user.is_authenticated:
             context["wallet"] = Wallet.objects.get(user=self.request.user)
         context["hunts"] = Hunt.objects.exclude(plan="Free")[:4]


### PR DESCRIPTION
<img width="1332" alt="Screenshot 2021-04-15 at 7 50 14 PM" src="https://user-images.githubusercontent.com/44541855/114885367-329b9380-9e24-11eb-9ce6-25e8f318ab30.png">

This PR aims to add captcha on report page and fix issue #730 .

Please review it @fredfalcon , @souravbadami .
Thanks.