### PR TITLE
facebook share fixed

### DIFF
--- a/website/templates/issue.html
+++ b/website/templates/issue.html
@@ -159,9 +159,9 @@
             <a class="tweet-btn fa fa-twitter btn btn-xs tweet-btn"
                 href="https://twitter.com/intent/tweet?text=Bug on @{{ object.domain_title }} - {{ object.description }}"
                 data-size="small"> Tweet</a>
-            <span class="fb-share-button" data-href="https://www.bugheist.com/issue/{{ object.id }} "
+            <span class="fb-share-button"
                 data-layout="button_count" data-size="small" data-mobile-iframe="true">
-                <a class="fb-xfbml-parse-ignore btn btn-primary btn-xs fb-btn" target="_blank">
+                <a href="https://www.facebook.com/sharer/sharer.php?u=https://www.bugheist.com/issue/{{ object.id }}" class="fb-xfbml-parse-ignore btn btn-primary btn-xs fb-btn" target="_blank">
                     <i class="fa fa-facebook fa-white"></i> Share
                 </a>
             </span>


### PR DESCRIPTION
as mentioned in  Facebook share button not working #853 

now by clicking on the icon it will redirect you to this page
![image](https://user-images.githubusercontent.com/68425016/172777224-172667fe-a07d-4163-b09f-36ae506bf66e.png)
