### PR TITLE
large filename error fix

### DIFF
--- a/website/views.py
+++ b/website/views.py
@@ -554,8 +554,16 @@ class IssueCreate(IssueBaseCreate, CreateView):
             )
         return initial
 
-    def form_valid(self, form):
+    def post(self, request, *args, **kwargs):
         
+        if len(request.FILES['screenshot'].name)>99:
+            filename = request.FILES['screenshot'].name
+            extension = filename.split(".")[-1] 
+            request.FILES['screenshot'].name = filename[:88] + "." + extension
+
+        return super().post(request, *args, **kwargs)
+
+    def form_valid(self, form):
         tokenauth = False
         obj = form.save(commit=False)
         if self.request.user.is_authenticated:


### PR DESCRIPTION
Issue:  Automatically trim the filename for large file names so we don't get this error #741 
After: 
![image](https://user-images.githubusercontent.com/68425016/187643923-43086465-bd42-4a7f-a50c-c432e816502f.png)
if name is >99 then it is trimmed downed to 88
![image](https://user-images.githubusercontent.com/68425016/187644133-b1703593-f5db-45a6-a6d0-1109af3b8b17.png)
