### PR TITLE
user.username returns none handled by hdefault_if_none not by default. default excepts boolen

### DIFF
--- a/website/templates/issue.html
+++ b/website/templates/issue.html
@@ -223,7 +223,7 @@
                             {% endif %}
                         </div>
                         <div class="col-xs-8">
-                            <h3>Reported by {{ object.user.username|default:"Anonymous" }}</h3>
+                            <h3>Reported by {{ object.user.username|default_if_none:"Anonymous" }}</h3>
                             {% if object.user.username %}
                             <h4>Total Points of {{ object.user.username }} = {{ users_score }}</h4>
 


### PR DESCRIPTION
 Anonymous / Deleted users do not show as anonymous but they show as 404 profile pictures and empty names Issue : #752