### PR TITLE
Fix low contrast in index page

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -15,7 +15,7 @@ body {
 
 .navbar-default .tagline {
     font-size: 14px;
-    color: #999;
+    color: #555;
     line-height: 20px;
     padding-left: 5px;
     font-weight: 300;
@@ -145,7 +145,7 @@ a:hover {
 
 .page-sub-header {
     font-size: 22px;
-    color: #999;
+    color: #555;
     text-transform: uppercase;
     border-bottom: 1px solid #eee;
     padding: 20px 0;
@@ -157,7 +157,7 @@ a:hover {
     background-color: transparent;
     border-color: transparent;
     border-bottom: 1px solid #eee;
-    color: #999;
+    color: #555;
     text-align: center;
 }
 

--- a/website/static/css/text-slider.css
+++ b/website/static/css/text-slider.css
@@ -4,7 +4,7 @@
 
 .text-slider-line {
     display: none;
-    color: #6f6c6c;
+    color: #555;
 }
 
 /*.text-slider-list:first-of-type .text-slider-line{


### PR DESCRIPTION
Mentioned in #1013 
- I have darkened the grey texts to a contrast ratio of 7, which is AAA WCAG compliant.

Dark, contrast ratio: 7.4
![image](https://user-images.githubusercontent.com/103092293/219826794-0aad91d3-e916-4612-a098-cc5c44afe1f0.png)

Light, contrast ratio: 2.8
![image](https://user-images.githubusercontent.com/103092293/219826813-cd67cd66-fe34-4ee6-afa0-20c02b40f7d2.png)


