### PR TITLE
Ensure footer aligns to bottom of page

### DIFF
--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -48,23 +48,20 @@
         src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 </head>
 
-<body>
+<body class="relative min-h-[100vh] flex flex-col">
     
     {% comment %} navbar {% endcomment %}
         {% include "includes/navbar.html" %}
     {% comment %} navbar {% endcomment %}
 
-    <br><br><br><br>
-    <div id="wrapper">
-        <div id="page-wrapper">
+    <div id="wrapper" class="grow">
+        <div id="page-wrapper" class="relative">
             <div id="base-container" class="container">
                 {% block content %}
                 {% endblock %}
             </div>
         </div>
-        
     </div>
-    
     {% include "includes/footer.html" %}
 
 </body>

--- a/website/templates/includes/footer.html
+++ b/website/templates/includes/footer.html
@@ -1,8 +1,8 @@
 {% load static %}
 {% load i18n %}
 
-<footer class="bg-black text-white pt-12 pb-8 px-12">
-    <div class="mx-auto px-4 container overflow-hidden flex flex-col lg:flex-row justify-between">
+<footer class="bg-black text-white pt-12 pb-8 px-12 bottom-0 relative">
+    <div class="mx-auto px-4 !container overflow-hidden flex flex-col lg:flex-row justify-between">
         <a href="/" class="block mr-4 w-1/2">
             <img src="{% static 'img/logo_white.png' %}" class="w-[200px] ml-4 lg:ml-0" alt="footer logo">
         </a>

--- a/website/templates/includes/navbar.html
+++ b/website/templates/includes/navbar.html
@@ -6,7 +6,7 @@
 {% load i18n %}
 
 
-<nav class="navbar-default navbar-fixed-top h-[80px] w-screen flex flex-col justify-center items-center">
+<nav class="navbar-default relative top-0 border-b h-[80px] w-screen flex flex-col justify-center items-center">
     <div class="flex w-[97vw] justify-between items-center">
         <div class="flex items-center gap-[30px] ml-[20px]">
             <!-- Settings Icon -->
@@ -223,7 +223,3 @@
             </ul> {% endcomment %}
     </div>
 </nav>
-
-<div id="margin-cont">
-
-</div>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -31,7 +31,7 @@
     </div>
     <br>
 </section>
-<div class="container-footer">
+<div class="">
     <center>
         <div class="row">
             <div class="col-sm-4">

--- a/website/templates/report.html
+++ b/website/templates/report.html
@@ -120,6 +120,7 @@
                 </button>
 
         </div>
+    </div>
 </form>
 <script type="text/javascript">
     $(function () {


### PR DESCRIPTION
Resolves #826 
I have:
- modified the body tag to ensure that it has a minimum height of the screen height (100vh).
- made the body tag a column flex box
- made the content wrapper grow to fill the minimum screen height if needed.
- changed the navbar from position: fixed to position: relative, with a top: 0px rule.

Additional:
- The footer's 'container' class was clashing with bootstrap and causing x-overflow, so I made it !important.
- I removed the container-footer class on the index page, it was causing overflow.

The report a bug page is a bit messed up, I'll open an issue for it.

### Before:
![image](https://user-images.githubusercontent.com/103092293/219908703-5b3430d2-79fa-4057-a85a-2a15670cbdc7.png)

### After:
![image](https://user-images.githubusercontent.com/103092293/219908689-c8db7ef0-52c6-4ca6-927d-a2f671977353.png)