### PR TITLE
Fixed chopped off nav search element in chrome

### DIFF
--- a/website/templates/includes/navbar.html
+++ b/website/templates/includes/navbar.html
@@ -61,7 +61,7 @@
         </div>
 
         <!-- Search Bar -->
-        <form class="" action="/search" method="get">
+        <form class="h-max m-0" action="/search" method="get">
             <div class="flex items-center w-full h-full nav-hidden sm:!block">
                 <i class="fa fa-search relative left-[28px] top-[-2px] text-gray-700 text-base nav-hidden lg:!inline-block"></i>
                 <input type="text" name="query" placeholder="{% trans "Search" %}" class="w-[200px] h-[38px] pl-[30px] nav-hidden lg:!inline-block">


### PR DESCRIPTION
Fixes #1082 

- I have added m-0 and h-max classes to the form element in the navbar

This should keep the element more centered on both firefox and chrome, and it should stop the chrome element from floating to the top of the page.

![image](https://user-images.githubusercontent.com/103092293/221116625-8ec85a3f-72b0-4b87-99bd-692beb057f21.png)
