### PR TITLE
Add fields to response to `/api/v1/issues/` POST request

### DIFF
--- a/website/api/views.py
+++ b/website/api/views.py
@@ -172,6 +172,13 @@ class IssueViewSet(viewsets.ModelViewSet):
 
         issue = Issue.objects.filter(id=pk).first()
         return Response(self.get_issue_info(request,issue))
+    
+    def create(self, request, *args, **kwargs):
+        response = super().create(request, *args, **kwargs)
+        data = response.data
+        issue = Issue.objects.filter(id=data["id"]).first()
+        return Response(self.get_issue_info(request,issue))
+
 
 class LikeIssueApiView(APIView):
 


### PR DESCRIPTION
Fixes #1102 

Now the response contains all the additional fields as in a GET request.