### PR TITLE
Allow /api/v1/issues to have multiple screenshots

### DIFF
--- a/website/api/views.py
+++ b/website/api/views.py
@@ -8,7 +8,7 @@ from django.template.loader import render_to_string
 from django.db.models import Sum
 from django.contrib.auth.models import AnonymousUser
 
-from rest_framework import viewsets, filters
+from rest_framework import viewsets, filters, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.authentication import TokenAuthentication
@@ -179,10 +179,10 @@ class IssueViewSet(viewsets.ModelViewSet):
     
     def create(self, request, *args, **kwargs):
         if len(self.request.FILES.getlist("screenshots")) > 5:
-            raise ValidationError({"error": "Max limit of 5 images!"})
+            return Response({"error": "Max limit of 5 images!"}, status=status.HTTP_400_BAD_REQUEST)
         
         if len(self.request.FILES.getlist("screenshots")) == 0:
-            raise ValidationError({"error": "Upload atleast one image!"})
+            return Response({"error": "Upload atleast one image!"}, status=status.HTTP_400_BAD_REQUEST)
         
         response = super().create(request, *args, **kwargs)
         data = response.data

--- a/website/api/views.py
+++ b/website/api/views.py
@@ -1,6 +1,9 @@
 from datetime import datetime
+import uuid
 
 from django.core.mail import send_mail
+from django.core.files.storage import default_storage
+from django.forms import ValidationError
 from django.template.loader import render_to_string
 from django.db.models import Sum
 from django.contrib.auth.models import AnonymousUser
@@ -16,6 +19,7 @@ from django.conf import settings
 from website.models import (
     Issue,
     Domain,
+    IssueScreenshot,
 )
 from website.serializers import (
     IssueSerializer,
@@ -174,9 +178,24 @@ class IssueViewSet(viewsets.ModelViewSet):
         return Response(self.get_issue_info(request,issue))
     
     def create(self, request, *args, **kwargs):
+        if len(self.request.FILES.getlist("screenshots")) > 5:
+            raise ValidationError({"error": "Max limit of 5 images!"})
+        
+        if len(self.request.FILES.getlist("screenshots")) == 0:
+            raise ValidationError({"error": "Upload atleast one image!"})
+        
         response = super().create(request, *args, **kwargs)
         data = response.data
         issue = Issue.objects.filter(id=data["id"]).first()
+
+
+        for screenshot in self.request.FILES.getlist("screenshots"):
+            filename = screenshot.name
+            extension = filename.split(".")[-1] 
+            screenshot.name = filename[:99] + str(uuid.uuid4()) + "." + extension            
+            default_storage.save(f"screenshots/{screenshot.name}",screenshot)
+            IssueScreenshot.objects.create(image=f"screenshots/{screenshot.name}",issue=issue)
+
         return Response(self.get_issue_info(request,issue))
 
 

--- a/website/models.py
+++ b/website/models.py
@@ -211,7 +211,7 @@ class Issue(models.Model):
     status = models.CharField(max_length=10, default="open", null=True, blank=True)
     user_agent = models.CharField(max_length=255, default="", null=True, blank=True)
     ocr = models.TextField(default="", null=True, blank=True)
-    screenshot = models.ImageField(upload_to="screenshots", validators=[validate_image])
+    screenshot = models.ImageField(upload_to="screenshots", null=True, blank=True, validators=[validate_image])
     closed_by = models.ForeignKey(
         User, null=True, blank=True, related_name="closed_by", on_delete=models.CASCADE
     )


### PR DESCRIPTION
Required for https://github.com/OWASP/BLT-Flutter/issues/290

`/api/v1/issues` has no logic to allow POST requests to have multiple screenshots. Therefore, only one screenshot could be linked with an issue via `/api/v1/issues`

I have updated the logic by creating an instance of `IssueScreenshot` for every screenshot sent to `/api/v1/issues` to fix the above mentioned behavior.

PS. merging this PR will break the reporting issue feature in the app, because now image files are to have `screenshots` field rather than `screenshot`. However, I am ready with the updated code for the app, as soon as this PR is merged, I'll raise one in BLT-Flutter