### PR TITLE
fix: Top hunts UI error message is not at center of screen for small screens #1267

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -572,11 +572,3 @@ i.fa-5x {
 .profileimage{
     border-radius:50%;
     }
-
-
-    @media (max-width: 640px){
-        .react{
-            color: red !important;
-          justify-content: center !important;
-        }
-      }

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -572,3 +572,11 @@ i.fa-5x {
 .profileimage{
     border-radius:50%;
     }
+
+
+    @media (max-width: 640px){
+        .react{
+            color: red !important;
+          justify-content: center !important;
+        }
+      }

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -8,7 +8,6 @@
 {% block content %}
 <script src="{% static "js/jquery.validate.js" %}"></script>
 <script src="{% static 'js/activity.js' %}"></script>
-<link rel="stylesheet" type="text/css" href="style.css" />
 <div class="w-full h-[30rem] flex flex-col  space-y-14 items-center">
     <p class="text-5xl text-center mt-20 font-sans sm:text-6xl lg:text-7xl">Find Bugs, Win Points and Prizes</p>
 
@@ -111,7 +110,7 @@
 
 <p class="text-7xl text-center mb-10 font-sans text-[#B1B1B1]">TOP HUNTS</p>
 
-<div class="flex items-center flex-wrap items-center w-full  justify-between mb-[100px] mt-20 sm:justify-center react">
+<div class="flex items-center flex-wrap items-center w-full  justify-between mb-[100px] mt-20 sm:justify-center ">
 
     {% if top_hunts %}
 
@@ -136,7 +135,9 @@
         {% endfor %}
     
         {% else %}
-            <p class="text-red-500 justify-content:center">No ongoing hunt's found.</p>
+        <div class="w-full flex justify-center">
+            <p class="text-red-500">No ongoing hunt's found.</p>
+       </div>
         {% endif %}
 
 </div>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -8,8 +8,7 @@
 {% block content %}
 <script src="{% static "js/jquery.validate.js" %}"></script>
 <script src="{% static 'js/activity.js' %}"></script>
-
-
+<link rel="stylesheet" type="text/css" href="style.css" />
 <div class="w-full h-[30rem] flex flex-col  space-y-14 items-center">
     <p class="text-5xl text-center mt-20 font-sans sm:text-6xl lg:text-7xl">Find Bugs, Win Points and Prizes</p>
 
@@ -112,7 +111,7 @@
 
 <p class="text-7xl text-center mb-10 font-sans text-[#B1B1B1]">TOP HUNTS</p>
 
-<div class="flex items-center flex-wrap items-center w-full  justify-between mb-[100px] mt-20 sm:justify-center">
+<div class="flex items-center flex-wrap items-center w-full  justify-between mb-[100px] mt-20 sm:justify-center react">
 
     {% if top_hunts %}
 
@@ -137,7 +136,7 @@
         {% endfor %}
     
         {% else %}
-            <p class="text-red-500">No ongoing hunt's found.</p>
+            <p class="text-red-500 justify-content:center">No ongoing hunt's found.</p>
         {% endif %}
 
 </div>


### PR DESCRIPTION
## Fixed #1267 Bug: Top hunts UI error message is not at center of screen for small screens

## Before
![Screenshot 2023-06-15 231311](https://github.com/OWASP/BLT/assets/105916104/28e9c84c-a195-450f-a9a9-2009e2bbbd58)

## After


![Screenshot 2023-06-15 231516](https://github.com/OWASP/BLT/assets/105916104/3d4bbfb3-26b1-4e48-8845-eb1e870f535b)


## Made changes in  **index.html**  and **style.css** file


@AtmegaBuzz Please review and merge.
