### PR TITLE
Feature: Support new model changes in new Bughunt API

### DIFF
--- a/blt/urls.py
+++ b/blt/urls.py
@@ -64,6 +64,7 @@ from website.api.views import (
     StatsApiViewset,
     UrlCheckApiViewset,
     BugHuntApiViewset,
+    BugHuntApiViewsetV2
 )
 from company.views import ShowBughuntView
 from website.alternative_views import (
@@ -367,6 +368,9 @@ urlpatterns = [
     re_path(r"^api/v1/urlcheck/$", UrlCheckApiViewset.as_view(), name="url_check"),
     re_path(
         r"^api/v1/hunt/$",BugHuntApiViewset.as_view(),name="hunt_details"
+    ),
+    re_path(
+        r"^api/v2/hunts/$",BugHuntApiViewsetV2.as_view(),name="hunts_detail_v2"
     ),
     re_path(r"^api/v1/userscore/$", website.views.get_score, name="get_score"),
     re_path(r"^authenticate/", CustomObtainAuthToken.as_view()),

--- a/website/serializers.py
+++ b/website/serializers.py
@@ -1,4 +1,4 @@
-from website.models import Issue, Points, User, UserProfile, Domain
+from website.models import Issue, Points, User, UserProfile, Domain, Hunt, HuntPrize
 from rest_framework import  serializers
 from django.db.models import Sum
 
@@ -70,3 +70,16 @@ class DomainSerializer(serializers.ModelSerializer):
         model = Domain
         fields = '__all__'
 
+
+    
+class BugHuntPrizeSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = HuntPrize
+        fields = '__all__'
+
+class BugHuntSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Hunt
+        fields = '__all__'


### PR DESCRIPTION
# FIX List Bughunt API Supporting new Bughunt Model changes #1233
# New Bughunt API supports new model with paginated response
As we have model changes and we are storing prizes in new table

# API Response
```
{
    "count": 3,
    "next": null,
    "previous": null,
    "results": [
        {
            "id": 19,
            "name": "Hunt 11 Updated",
            "description": "dasdasdasda\r\nsd\r\nasdasdasdasd",
            "url": "https://www.bugheist.com",
            "prize": null,
            "prize_winner": "0.00",
            "prize_runner": "0.00",
            "prize_second_runner": "0.00",
            "logo": "/media/logos/2e3c37afc-d634-4933-b9e2-4f05e6e3a7c9.png",
            "banner": "/media/banners/28ae4b773-e749-435f-b856-a492c9970289.png",
            "plan": "",
            "txn_id": null,
            "color": null,
            "created": "2023-07-27T06:42:24.846190Z",
            "starts_on": "2023-07-27T00:00:00Z",
            "end_on": "2029-01-12T00:00:00Z",
            "is_published": true,
            "result_published": false,
            "modified": "2023-07-27T08:09:08.225947Z",
            "domain": 1,
            "prizes": [
                {
                    "id": 7,
                    "name": "Winner 1",
                    "value": 1000,
                    "no_of_eligible_projects": 1,
                    "valid_submissions_eligible": false,
                    "prize_in_crypto": true,
                    "description": "dasdasdasdasdad",
                    "hunt": 19
                },
                {
                    "id": 8,
                    "name": "Winner All",
                    "value": 1000,
                    "no_of_eligible_projects": 1,
                    "valid_submissions_eligible": true,
                    "prize_in_crypto": true,
                    "description": "asdasdsdasdasd",
                    "hunt": 19
                }
            ]
        },
}
```
