### PR TITLE
Patch: Allow viewing of previous hunts on Home page

### DIFF
--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -107,8 +107,18 @@
     </div>
 </div>
 
+{% if ended_hunts %}
+    <p class="text-7xl text-center mb-8 font-sans text-[#B1B1B1]">ENDED HUNTS</p>
+    <div class="w-full flex justify-center">
+        <a href="/" class="px-8 py-3 bg-red-500 rounded-lg text-center text-white font-bold text-2xl">View Ongoing Hunts</a>
+    </div>
+{% else %}
+    <p class="text-7xl text-center mb-8 font-sans text-[#B1B1B1]">LATEST HUNTS</p>
+    <div class="w-full flex justify-center">
+        <a href="/?latest_hunts=ended" class="px-8 py-3 bg-red-500 rounded-lg text-center text-white font-bold text-2xl">View Ended Hunts</a>
+    </div>
+{% endif %}
 
-<p class="text-7xl text-center mb-10 font-sans text-[#B1B1B1]">LATEST HUNTS</p>
 
 <div class="flex items-center flex-wrap w-full justify-between mb-[100px] mt-20 sm:justify-center ">
 

--- a/website/views.py
+++ b/website/views.py
@@ -99,6 +99,8 @@ def index(request, template="index.html"):
     except:
         pass
 
+    latest_hunts_filter = request.GET.get("latest_hunts",None)
+
     bug_count = Issue.objects.all().count()
     user_count = User.objects.all().count()
     hunt_count = Hunt.objects.all().count()
@@ -131,7 +133,13 @@ def index(request, template="index.html"):
         'end_on__day',
         'end_on__month',
         'end_on__year',
-        ).annotate(total_prize=Sum("huntprize__value")).filter(is_published=True,result_published=False).order_by("-created")[:3]
+    ).annotate(total_prize=Sum("huntprize__value"))
+
+    if latest_hunts_filter != None:
+        top_hunts = top_hunts.filter(result_published=True).order_by("-created")[:3]
+    else:
+        top_hunts = top_hunts.filter(is_published=True,result_published=False).order_by("-created")[:3]
+
 
     context = {
         "server_url": request.build_absolute_uri('/'),
@@ -153,7 +161,8 @@ def index(request, template="index.html"):
         "activity_screenshots":activity_screenshots,
         "top_companies":top_companies,
         "top_testers":top_testers,
-        "top_hunts": top_hunts 
+        "top_hunts": top_hunts,
+        "ended_hunts": False if latest_hunts_filter == None else True 
     }
     return render(request, template, context)
 

--- a/website/views.py
+++ b/website/views.py
@@ -744,10 +744,10 @@ class IssueCreate(IssueBaseCreate, CreateView):
         # automatically add specified hunt to dropdown of Bugreport
         report_on_hunt = self.request.GET.get("hunt",None)
         if report_on_hunt:
-            context["hunts"] = Hunt.objects.values("id","name").filter(id=report_on_hunt)
+            context["hunts"] = Hunt.objects.values("id","name").filter(id=report_on_hunt,is_published=True,result_published=False)
             context["report_on_hunt"] = True
         else:    
-            context["hunts"] = Hunt.objects.values("id","name").all()
+            context["hunts"] = Hunt.objects.values("id","name").filter(is_published=True,result_published=False)
             context["report_on_hunt"] = False
 
 


### PR DESCRIPTION
### Fix show ongoing bughunts in report page select hunt dropdown.

### Patch: Allow viewing of previous hunts on Home page

![patch1](https://github.com/OWASP/BLT/assets/68425016/e06098ff-ce88-45f7-b11e-a7d44d479186)
![patch2](https://github.com/OWASP/BLT/assets/68425016/3c34da9e-cc8a-49f8-adae-321e1026cf30)
