### PR TITLE
Fixed hoziontal overflow for Navbar

### DIFF
--- a/website/templates/includes/navbar.html
+++ b/website/templates/includes/navbar.html
@@ -7,7 +7,7 @@
 {% load custom_tags %}
 
 
-<nav class="navbar-default relative top-0 border-b h-[80px] w-screen flex flex-col justify-center items-center">
+<nav class="navbar-default relative top-0 border-b h-[80px] w-auto flex flex-col justify-center items-center">
     <div class="flex w-[97vw] justify-between items-center">
         <div class="flex items-center gap-[30px] ml-[20px]">
             <!-- Settings Icon -->


### PR DESCRIPTION
This pull request solves #1291 issue.

This removes the unnecessary horizontal scroll bar.

Before:
![navbar before](https://github.com/OWASP/BLT/assets/97180942/d7d1dbfc-6655-4a3b-8921-2b036a13fa2a)

After:
![Navbar after](https://github.com/OWASP/BLT/assets/97180942/0948426c-0f9e-49cc-b01f-ed78661ddaaf)

