### PR TITLE
Bug #1440 Fixed

### DIFF
--- a/website/templates/includes/md_editor.html
+++ b/website/templates/includes/md_editor.html
@@ -1,6 +1,6 @@
 <script src="https://cdn.tailwindcss.com"></script>
 
-<div class="w-full container p-4">
+<div class="w-full p-4">
 
   <div class="w-full h-full bg-white rounded-lg shadow-lg p-4">
     <div class="w-full flex flex-col items-center justify-between mb-4 md:flex-row md:justify-between">

--- a/website/templates/list_view.html
+++ b/website/templates/list_view.html
@@ -10,14 +10,24 @@
         <div class="col-md-12">
             <div class="text-center">
                 {% if page_obj.has_previous %}
-                    <a href="?page={{ page_obj.previous_page_number }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}"
-                       class="btn btn-default">Prev</a>
+                    <a href="?page=1{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}"
+                       class="btn btn-default">First</a>
+                {% else %}
+                    <button class="btn btn-default" disabled>First</button>
                 {% endif %}
-                <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+                {% for num in page_obj.paginator.page_range %}
+                    {% if num == page_obj.number %}
+                        <button class="btn btn-default" disabled>{{num}}</button>
+                    {% elif num > page_obj.number|add:"-5" and num < page_obj.number|add:"5" %}
+                        <a href="?page={{ num }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}" class="btn btn-default">{{num}}</a>
+                    {% endif %}
+                {% endfor %}
                 {% if page_obj.has_next %}
-                    <a href="?page={{ page_obj.next_page_number }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}"
-                       class="btn btn-default">Next</a>
+                    <a href="?page={{ page_obj.paginator.num_pages }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}" class="btn btn-default">Last</a>
+                {% else %}
+                    <button class="btn btn-default" disabled>Last</button>
                 {% endif %}
+                <div>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</div>
             </div>
         </div>
     {% endif %}
@@ -38,14 +48,23 @@
             <div class="col-md-12">
                 <div class="text-center">
                     {% if page_obj.has_previous %}
-                        <a href="?page={{ page_obj.previous_page_number }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}"
-                           class="btn btn-default">Prev</a>
+                        <a href="?page=1{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}" class="btn btn-default">First</a>
+                    {% else %}
+                        <button class="btn btn-default" disabled>First</button>
                     {% endif %}
-                    <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+                    {% for num in page_obj.paginator.page_range %}
+                        {% if num == page_obj.number %}
+                            <button class="btn btn-default" disabled>{{num}}</button>
+                        {% elif num > page_obj.number|add:"-5" and num < page_obj.number|add:"5" %}
+                            <a href="?page={{ num }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}" class="btn btn-default">{{num}}</a>
+                        {% endif %}
+                    {% endfor %}
                     {% if page_obj.has_next %}
-                        <a href="?page={{ page_obj.next_page_number }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}"
-                           class="btn btn-default">Next</a>
+                        <a href="?page={{ page_obj.paginator.num_pages }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}" class="btn btn-default">Last</a>
+                    {% else %}
+                        <button class="btn btn-default" disabled>Last</button>
                     {% endif %}
+                        <div>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</div>
                 </div>
             </div>
         {% endif %}

--- a/website/templates/list_view.html
+++ b/website/templates/list_view.html
@@ -10,24 +10,14 @@
         <div class="col-md-12">
             <div class="text-center">
                 {% if page_obj.has_previous %}
-                    <a href="?page=1{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}"
-                       class="btn btn-default">First</a>
-                {% else %}
-                    <button class="btn btn-default" disabled>First</button>
+                    <a href="?page={{ page_obj.previous_page_number }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}"
+                       class="btn btn-default">Prev</a>
                 {% endif %}
-                {% for num in page_obj.paginator.page_range %}
-                    {% if num == page_obj.number %}
-                        <button class="btn btn-default" disabled>{{num}}</button>
-                    {% elif num > page_obj.number|add:"-5" and num < page_obj.number|add:"5" %}
-                        <a href="?page={{ num }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}" class="btn btn-default">{{num}}</a>
-                    {% endif %}
-                {% endfor %}
+                <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
                 {% if page_obj.has_next %}
-                    <a href="?page={{ page_obj.paginator.num_pages }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}" class="btn btn-default">Last</a>
-                {% else %}
-                    <button class="btn btn-default" disabled>Last</button>
+                    <a href="?page={{ page_obj.next_page_number }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}"
+                       class="btn btn-default">Next</a>
                 {% endif %}
-                <div>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</div>
             </div>
         </div>
     {% endif %}
@@ -48,23 +38,14 @@
             <div class="col-md-12">
                 <div class="text-center">
                     {% if page_obj.has_previous %}
-                        <a href="?page=1{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}" class="btn btn-default">First</a>
-                    {% else %}
-                        <button class="btn btn-default" disabled>First</button>
+                        <a href="?page={{ page_obj.previous_page_number }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}"
+                           class="btn btn-default">Prev</a>
                     {% endif %}
-                    {% for num in page_obj.paginator.page_range %}
-                        {% if num == page_obj.number %}
-                            <button class="btn btn-default" disabled>{{num}}</button>
-                        {% elif num > page_obj.number|add:"-5" and num < page_obj.number|add:"5" %}
-                            <a href="?page={{ num }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}" class="btn btn-default">{{num}}</a>
-                        {% endif %}
-                    {% endfor %}
+                    <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
                     {% if page_obj.has_next %}
-                        <a href="?page={{ page_obj.paginator.num_pages }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}" class="btn btn-default">Last</a>
-                    {% else %}
-                        <button class="btn btn-default" disabled>Last</button>
+                        <a href="?page={{ page_obj.next_page_number }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}"
+                           class="btn btn-default">Next</a>
                     {% endif %}
-                        <div>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</div>
                 </div>
             </div>
         {% endif %}


### PR DESCRIPTION
**Fix #1440**
removed bootstrap reference "container"

Bootstrap was conflicting with Tailwind and hence we were not getting the expected results

Before: 
<img width="1440" alt="Screenshot 2023-09-26 at 10 00 18 PM" src="https://github.com/OWASP/BLT/assets/69814108/73f76ea0-b58b-4de6-86ad-a62474eb2bb5">

After:

<img width="1440" alt="Screenshot 2023-09-26 at 10 00 53 PM" src="https://github.com/OWASP/BLT/assets/69814108/cf87f79b-762a-49e3-9af2-4786b536ae35">
