### PR TITLE
Pagination with Page Numbers

### DIFF
--- a/website/templates/list_view.html
+++ b/website/templates/list_view.html
@@ -10,14 +10,24 @@
         <div class="col-md-12">
             <div class="text-center">
                 {% if page_obj.has_previous %}
-                    <a href="?page={{ page_obj.previous_page_number }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}"
-                       class="btn btn-default">Prev</a>
+                    <a href="?page=1{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}"
+                       class="btn btn-default">First</a>
+                {% else %}
+                    <button class="btn btn-default" disabled>First</button>
                 {% endif %}
-                <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+                {% for num in page_obj.paginator.page_range %}
+                    {% if num == page_obj.number %}
+                        <button class="btn btn-default" disabled>{{num}}</button>
+                    {% elif num > page_obj.number|add:"-5" and num < page_obj.number|add:"5" %}
+                        <a href="?page={{ num }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}" class="btn btn-default">{{num}}</a>
+                    {% endif %}
+                {% endfor %}
                 {% if page_obj.has_next %}
-                    <a href="?page={{ page_obj.next_page_number }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}"
-                       class="btn btn-default">Next</a>
+                    <a href="?page={{ page_obj.paginator.num_pages }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}" class="btn btn-default">Last</a>
+                {% else %}
+                    <button class="btn btn-default" disabled>Last</button>
                 {% endif %}
+                <div>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</div>
             </div>
         </div>
     {% endif %}
@@ -38,14 +48,23 @@
             <div class="col-md-12">
                 <div class="text-center">
                     {% if page_obj.has_previous %}
-                        <a href="?page={{ page_obj.previous_page_number }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}"
-                           class="btn btn-default">Prev</a>
+                        <a href="?page=1{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}" class="btn btn-default">First</a>
+                    {% else %}
+                        <button class="btn btn-default" disabled>First</button>
                     {% endif %}
-                    <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+                    {% for num in page_obj.paginator.page_range %}
+                        {% if num == page_obj.number %}
+                            <button class="btn btn-default" disabled>{{num}}</button>
+                        {% elif num > page_obj.number|add:"-5" and num < page_obj.number|add:"5" %}
+                            <a href="?page={{ num }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}" class="btn btn-default">{{num}}</a>
+                        {% endif %}
+                    {% endfor %}
                     {% if page_obj.has_next %}
-                        <a href="?page={{ page_obj.next_page_number }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}"
-                           class="btn btn-default">Next</a>
+                        <a href="?page={{ page_obj.paginator.num_pages }}{% if user %}&user={{ user }}{% endif %}{% if label %}&label={{ label }}{% endif %}" class="btn btn-default">Last</a>
+                    {% else %}
+                        <button class="btn btn-default" disabled>Last</button>
                     {% endif %}
+                        <div>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</div>
                 </div>
             </div>
         {% endif %}


### PR DESCRIPTION
Added: Pagination with Page Numbers

Pagination with Page Number Added for Smoother Navigation. It will show 10 page numbers relative to current page number(+5 and -5 of current page)

P.S: Had some issues with the last PR(#1457), the code was removed because of some confusion. So this is the updated PR now.

**Before**
<img width="252" alt="Screenshot 2023-10-05 at 2 15 49 AM" src="https://github.com/OWASP/BLT/assets/69814108/cf9509da-5e42-4041-9234-340979c700ad">

**After**
<img width="334" alt="Screenshot 2023-10-05 at 2 15 36 AM" src="https://github.com/OWASP/BLT/assets/69814108/0ec1a2f3-5eb4-4bbd-be16-d836647377c3">