### PR TITLE
Fix code scanning alert issue #1357

### DIFF
--- a/website/static/js/jquery.atwho.js
+++ b/website/static/js/jquery.atwho.js
@@ -50,7 +50,7 @@
             _a = decodeURI("%C3%80");
             _y = decodeURI("%C3%BF");
             space = acceptSpaceBar ? "\ " : "";
-            regexp = new RegExp(flag + "([A-Za-z" + _a + "-" + _y + "0-9_" + space + "\'\.\+\-]*)$|" + flag + "([^\\x00-\\xff]*)$", 'gi');
+            regexp = new RegExp(flag + "([A-Za-z" + _a + "-" + _y + "0-9_" + space + '\'\.\+\-]*)$|' + flag + "([^\\x00-\\xff]*)$", 'gi');
             match = regexp.exec(subtext);
             if (match) {
                 return match[2] || match[1];


### PR DESCRIPTION
fix #1357 
Work:
    1. at "website/static/js/jquery.atwho.js" file remove the unnecessary escape sequence
    
**NOTE**:
    after make the PR - lot's of code scanning alert issue are solve now like : #1355 #1354  and many others 

screenshot:
![image](https://github.com/OWASP/BLT/assets/97744811/a5c38d74-c620-47a6-8aef-d3b1c7458632)
 