### PR TITLE
fix security issue #1329

### DIFF
--- a/website/views.py
+++ b/website/views.py
@@ -735,7 +735,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
                 return JsonResponse("Created", safe=False)
             else:
                 self.process_issue(self.request.user, obj, domain_exists, domain)
-                return HttpResponseRedirect(redirect_url)
+                return HttpResponseRedirect(redirect_url) 
         
         return create_issue(self,form)
 

--- a/website/views.py
+++ b/website/views.py
@@ -735,7 +735,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
                 return JsonResponse("Created", safe=False)
             else:
                 self.process_issue(self.request.user, obj, domain_exists, domain)
-                return HttpResponseRedirect(redirect_url) 
+                return HttpResponseRedirect('/report')
         
         return create_issue(self,form)
 

--- a/website/views.py
+++ b/website/views.py
@@ -735,7 +735,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
                 return JsonResponse("Created", safe=False)
             else:
                 self.process_issue(self.request.user, obj, domain_exists, domain)
-                return HttpResponseRedirect(self.request.META.get("HTTP_REFERER"))
+                return HttpResponseRedirect(redirect_url)
         
         return create_issue(self,form)
 


### PR DESCRIPTION
fix - #1329 
issue : "self.request.META.get("HTTP_REFERER")" gets the location "/report" , which is also declares it, in  the variable 'redirect_url'
screenshot : 
![image](https://github.com/OWASP/BLT/assets/97744811/f7291a6c-081d-4fe0-bcae-d651c44248e5)
