### PR TITLE
fix #1587 leaderboard is cut off

### DIFF
--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -38,7 +38,7 @@
                 <div class="list-group">
                     {% if leaderboard %}
                     {% for leader in leaderboard %}
-                    <div class="list-group-item activity-strip flex overflow-hidden" style="height: 80px; border: 1px solid #DDDDDD">
+                    <div class="list-group-item activity-strip flex overflow-hidden" style="height: 80px; display:flex; border: 1px solid #DDDDDD">
                         <span class="h-full w-1/3 flex justify-center items-center">
                             {% if leader.socialaccount_set.all.0.get_avatar_url %}
                             <img src="{{ leader.socialaccount_set.all.0.get_avatar_url }}" class="profileimage" width="50"


### PR DESCRIPTION
Fixes #1587 

Before 
<img width="1440" alt="Screenshot 2023-11-14 at 12 42 55 PM" src="https://github.com/OWASP/BLT/assets/69814108/3254644b-a51e-4adc-9559-d7d91ebea773">

After
<img width="1440" alt="Screenshot 2023-11-14 at 12 42 45 PM" src="https://github.com/OWASP/BLT/assets/69814108/d83d6255-9abe-4b1d-94ce-bd673e9e3f10">
