### PR TITLE
limit bugs to 20

### DIFF
--- a/website/views.py
+++ b/website/views.py
@@ -188,7 +188,7 @@ def newhome(request, template="new_home.html"):
     except:
         pass
 
-    bugs=Issue.objects.exclude(Q(is_hidden=True) & ~Q(user_id=request.user.id))
+    bugs=Issue.objects.exclude(Q(is_hidden=True) & ~Q(user_id=request.user.id))[0:20]
     bugs_screenshots = {}
 
     for bug in bugs:


### PR DESCRIPTION
currently, loading the new home page fetches all the bugs and displays them making the initial loading time too much. Limited it to show first 20 bugs for now.