### PR TITLE
Task: Implement Deletion of Related Screenshots on Issue Deletion

### DIFF
--- a/website/models.py
+++ b/website/models.py
@@ -323,6 +323,12 @@ class IssueScreenshot(models.Model):
     image = models.ImageField(upload_to="screenshots", validators=[validate_image])
     issue = models.ForeignKey(Issue,on_delete=models.CASCADE,related_name="screenshots")
 
+    def delete (self, *args, **kwargs):
+        if self.image:
+            if os.path.isfile(self.image.path):
+                os.remove(self.image.path)
+        super(IssueScreenshot, self).delete(*args, **kwargs)
+
 
 @receiver(post_save, sender=Issue)
 def update_issue_image_access(sender, instance, **kwargs):

--- a/website/views.py
+++ b/website/views.py
@@ -1190,6 +1190,10 @@ def delete_issue(request, id):
     except:
         tokenauth = False
     issue = Issue.objects.get(id=id)
+    if request.user.is_superuser or request.user == issue.user or tokenauth:
+        screenshots = issue.screenshots.all()
+        for screenshot in screenshots:
+            screenshot.delete()
     if request.user.is_superuser or request.user == issue.user:
         issue.delete()
         messages.success(request, "Issue deleted")


### PR DESCRIPTION
work: Now, whenever a bug report is removed, all its associated screenshots are also cleaned up both from the database and the file system.

@DonnieBLT, could you please take a look? Thanks! (fixed : #1794 )