### PR TITLE
Use `is` instead of `==` for None comparisons

### DIFF
--- a/company/views.py
+++ b/company/views.py
@@ -49,7 +49,7 @@ def validate_company_user(func):
             Q(managers__in=[request.user])
         ).filter(company_id=company).first()
 
-        if company == None:
+        if company is None:
             return redirect("company_view")
         
         return func(self,request,company.company_id,*args,**kwargs)
@@ -64,7 +64,7 @@ def company_view(request,*args,**kwargs):
         messages.info(request,"Email not verified.")
         return redirect("/")
 
-    if (user==None or isinstance(user,AnonymousUser)):
+    if (user is None or isinstance(user,AnonymousUser)):
         messages.error(request,"Login with company or domain provided email.")
         return redirect("/accounts/login/")
     
@@ -80,7 +80,7 @@ def company_view(request,*args,**kwargs):
         Q(admin=user) | 
         Q(managers__in=[user])
     )
-    if (user_companies.first()==None):
+    if (user_companies.first() is None):
 
         messages.error(request,"You do not have a company, create one.")
         return redirect("register_company")        
@@ -108,7 +108,7 @@ class RegisterCompanyView(View):
             messages.info(request,"Email not verified.")
             return redirect("/")
 
-        if (user==None or isinstance(user,AnonymousUser)):
+        if (user is None or isinstance(user,AnonymousUser)):
             messages.error(request,"Login to create company")
             return redirect("/accounts/login/")
         
@@ -129,7 +129,7 @@ class RegisterCompanyView(View):
 
         company = Company.objects.filter(name=data["company_name"]).first()
 
-        if (company!=None):
+        if (company is not None):
             messages.error(request,"Company already exist.")
             return redirect("register_company")
 
@@ -182,7 +182,7 @@ class CompanyDashboardAnalyticsView(View):
         total_bug_hunts = Hunt.objects.filter(domain__company__company_id=company).count()
         total_domains = Domain.objects.filter(company__company_id=company).count()
         total_money_distributed = Issue.objects.filter(domain__company__company_id=company).aggregate(total_money=Sum('rewarded'))["total_money"]
-        total_money_distributed = 0 if total_money_distributed==None else total_money_distributed
+        total_money_distributed = 0 if total_money_distributed is None else total_money_distributed
 
         return {
                 'total_company_bugs':total_company_bugs,
@@ -418,11 +418,11 @@ class AddDomainView(View):
             "facebook": request.POST.get("facebook_url",None),
         }
 
-        if domain_data["name"] == None:
+        if domain_data["name"] is None:
             messages.error(request,"Enter domain name")
             return redirect("add_domain",company) 
         
-        if domain_data["url"] == None:
+        if domain_data["url"] is None:
             messages.error(request,"Enter domain url")
             return redirect("add_domain",company)
         
@@ -546,7 +546,7 @@ class DomainView(View):
             raise Http404("Domain not found")
 
         total_money_distributed = Issue.objects.filter(pk=domain["id"]).aggregate(total_money=Sum('rewarded'))["total_money"]
-        total_money_distributed = 0 if total_money_distributed==None else total_money_distributed
+        total_money_distributed = 0 if total_money_distributed is None else total_money_distributed
 
         total_bug_reported = Issue.objects.filter(pk=domain["id"]).count()
         total_bug_accepted = Issue.objects.filter(pk=domain["id"], verified=True).count()
@@ -639,7 +639,7 @@ class CompanyDashboardManageRolesView(View):
             ( Q(company__admin=request.user) | Q(managers__in=[request.user]) )   
         ).first()
         
-        if domain == None:
+        if domain is None:
             messages.error("you are not manager of this domain.")
             return redirect('company_manage_roles',company)
         
@@ -682,7 +682,7 @@ class ShowBughuntView(View):
         total_bug_accepted = hunt_issues.filter(verified=True).count()
 
         total_money_distributed = hunt_issues.aggregate(total_money=Sum('rewarded'))["total_money"]
-        total_money_distributed = (0 if total_money_distributed==None else total_money_distributed)
+        total_money_distributed = (0 if total_money_distributed is None else total_money_distributed)
 
 
         bughunt_leaderboard = hunt_issues.values("user__id","user__username","user__userprofile__user_avatar").filter(user__isnull=False,verified=True).annotate(count=Count('user__username')).order_by("-count")[:16]
@@ -790,7 +790,7 @@ class AddHuntView(View):
 
         domains = Domain.objects.values('id','name').filter(company__company_id=company)
 
-        if hunt_id != None:
+        if hunt_id is not None:
             return self.edit(request,company,companies,domains,hunt_id,*args,**kwargs)
 
         context = {
@@ -808,7 +808,7 @@ class AddHuntView(View):
         data = request.POST
 
         hunt_id = data.get("hunt_id",None) # when post is for edit hunt
-        is_edit = True if hunt_id != None else False
+        is_edit = True if hunt_id is not None else False
 
         if is_edit:
             hunt = get_object_or_404(Hunt,pk=hunt_id)
@@ -816,7 +816,7 @@ class AddHuntView(View):
 
         domain = Domain.objects.filter(id=data.get("domain",None)).first()
 
-        if domain == None:
+        if domain is None:
             messages.error(request,"Domain Does not exists")
             return redirect('add_bughunt',company)
 
@@ -827,14 +827,14 @@ class AddHuntView(View):
         end_date = datetime.strptime(end_date,"%m/%d/%Y").strftime("%Y-%m-%d %H:%M")
 
         hunt_logo = request.FILES.get("logo",None)
-        if hunt_logo != None:
+        if hunt_logo is not None:
             hunt_logo_file = hunt_logo.name.split(".")[0]
             extension = hunt_logo.name.split(".")[-1] 
             hunt_logo.name = hunt_logo_file[:99] + str(uuid.uuid4()) + "." + extension            
             default_storage.save(f"logos/{hunt_logo.name}",hunt_logo)
 
         webshot_logo = request.FILES.get("webshot",None) 
-        if webshot_logo != None:
+        if webshot_logo is not None:
             webshot_logo_file = webshot_logo.name.split(".")[0]
             extension = webshot_logo.name.split(".")[-1] 
             webshot_logo.name = webshot_logo_file[:99] + str(uuid.uuid4()) + "." + extension            
@@ -852,9 +852,9 @@ class AddHuntView(View):
             hunt.end_on = end_date
             hunt.is_published = False if data["publish_bughunt"] == "false" else True
             
-            if hunt_logo != None:
+            if hunt_logo is not None:
                 hunt.logo = f"logos/{hunt_logo.name}"
-            if webshot_logo != None:
+            if webshot_logo is not None:
                 hunt.banner = f"banners/{webshot_logo.name}"
             
             hunt.save()

--- a/website/api/views.py
+++ b/website/api/views.py
@@ -83,7 +83,7 @@ class UserProfileViewSet(viewsets.ModelViewSet):
         
         user_profile = UserProfile.objects.filter(user__id=pk).first()
 
-        if user_profile == None:
+        if user_profile is None:
             return Response({"detail": "Not found."},status=404)
         
         serializer = self.get_serializer(user_profile)
@@ -93,7 +93,7 @@ class UserProfileViewSet(viewsets.ModelViewSet):
         
         user_profile = request.user.userprofile
         
-        if user_profile==None:
+        if user_profile is None:
             return Response({"detail": "Not found."},status=404)
         
         instance = user_profile
@@ -142,7 +142,7 @@ class IssueViewSet(viewsets.ModelViewSet):
     
     def get_issue_info(self,request,issue):
         
-        if issue == None:
+        if issue is None:
             return {}
 
         screenshots = [
@@ -454,7 +454,7 @@ class UrlCheckApiViewset(APIView):
         
         domain_url = request.data.get("domain_url",None)
 
-        if domain_url == None or domain_url.strip() == "": 
+        if domain_url is None or domain_url.strip() == "": 
             return Response([])
 
         domain = domain_url.replace("https://","").replace("http://","").replace("www.","")

--- a/website/serializers.py
+++ b/website/serializers.py
@@ -18,7 +18,7 @@ class UserProfileSerializer(serializers.ModelSerializer):
     """
     def get_total_score(self,instance):
         score = Points.objects.filter(user=instance.user).aggregate(total_score=Sum('score')).get("total_score")
-        if score==None: return 0
+        if score is None: return 0
         return score
     
     def get_activities(self,instance):

--- a/website/templates/comments.html
+++ b/website/templates/comments.html
@@ -1,6 +1,6 @@
 <div class="comment_group">
     {% for comment in all_comment %}
-        {% if comment.parent == None %}
+        {% if comment.parent is None %}
             <blockquote>
             <div class="well comment -ml-11  ">
                 <div class="comment-actions flex-col space-y-5 p-5">
@@ -43,7 +43,7 @@
             </blockquote>
         {% endfor %}
 
-        {% if comment.parent == None %}
+        {% if comment.parent is None %}
             <form class="reply_form">
                 {% csrf_token %}
                 <div class="form-group">

--- a/website/templates/comments2.html
+++ b/website/templates/comments2.html
@@ -31,7 +31,7 @@
     {% endif %}
     <div class="comment_group">
         {% for comment in all_comment %}
-            {% if comment.parent == None %}
+            {% if comment.parent is None %}
                 <article class="p-6 mb-6 text-base bg-white rounded-lg ">
                     <footer class="flex justify-between items-center mb-2">
                         <div class="grid grid-cols-9 items-center justify-between">

--- a/website/templates/issue2.html
+++ b/website/templates/issue2.html
@@ -155,7 +155,7 @@
                                 <div class="w-full flex justify-between my-3">
                                     <p class="text-3xl font-bold">Submitted:</p>
                                     
-                                    {% if object.hunt == None %}
+                                    {% if object.hunt is None %}
                                     
                                     <span class="font-bold bg-red-600 px-5 py-1 text-white rounded-xl">Independently</span>
                                     

--- a/website/templates/search.html
+++ b/website/templates/search.html
@@ -91,7 +91,7 @@
                                 </div>
                                  <div style="padding:0px 75px;">
                                     <label style="font-size: 15px;">User points :</label>
-                                    {% if user.total_score == None %}
+                                    {% if user.total_score is None %}
                                         <span style="font-size: 15px;">0</span> Point
                                     {% else %}
                                         <span style="font-size: 15px;">{{ user.total_score|floatformat:0 }}</span> Points

--- a/website/views.py
+++ b/website/views.py
@@ -156,7 +156,7 @@ def index(request, template="index.html"):
         'end_on__year',
     ).annotate(total_prize=Sum("huntprize__value"))
 
-    if latest_hunts_filter != None:
+    if latest_hunts_filter is not None:
         top_hunts = top_hunts.filter(result_published=True).order_by("-created")[:3]
     else:
         top_hunts = top_hunts.filter(is_published=True,result_published=False).order_by("-created")[:3]
@@ -183,7 +183,7 @@ def index(request, template="index.html"):
         "top_companies":top_companies,
         "top_testers":top_testers,
         "top_hunts": top_hunts,
-        "ended_hunts": False if latest_hunts_filter == None else True 
+        "ended_hunts": False if latest_hunts_filter is None else True 
     }
     return render(request, template, context)
 
@@ -249,7 +249,7 @@ def newhome(request, template="new_home.html"):
     #     'end_on__year',
     # ).annotate(total_prize=Sum("huntprize__value"))
 
-    # if latest_hunts_filter != None:
+    # if latest_hunts_filter is not None:
     #     top_hunts = top_hunts.filter(result_published=True).order_by("-created")[:3]
     # else:
     #     top_hunts = top_hunts.filter(is_published=True,result_published=False).order_by("-created")[:3]
@@ -277,7 +277,7 @@ def newhome(request, template="new_home.html"):
         # "top_companies":top_companies,
         # "top_testers":top_testers,
         # "top_hunts": top_hunts,
-        # "ended_hunts": False if latest_hunts_filter == None else True 
+        # "ended_hunts": False if latest_hunts_filter is None else True 
     }
     return render(request, template, context)
 
@@ -778,7 +778,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
             clean_domain = obj.domain_name.replace("www.", "").replace("https://","").replace("http://","")
             domain = Domain.objects.filter(name=clean_domain).first()
 
-            domain_exists = False if domain==None else True 
+            domain_exists = False if domain is None else True 
 
             if not domain_exists:
                 domain = Domain.objects.create(
@@ -788,7 +788,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
                 domain.save()
             
             hunt = self.request.POST.get("hunt",None)
-            if hunt != None and hunt!="None":
+            if hunt is not None and hunt!="None":
                 hunt = Hunt.objects.filter(id=hunt).first()
                 obj.hunt = hunt
 
@@ -832,7 +832,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
 
             team_members_id = [member["id"] for member in User.objects.values("id").filter(email__in=self.request.POST.getlist("team_members"))] + [self.request.user.id]
             for member_id in team_members_id:
-                if member_id == None:
+                if member_id is None:
                     team_members_id.remove(member_id) # remove None values if user not exists
             obj.team_members.set(team_members_id)
 
@@ -2287,7 +2287,7 @@ def comment_on_issue(request, issue_pk):
         comment = request.POST.get("comment","")
         replying_to_input = request.POST.get("replying_to_input","").split("#")
         
-        if issue == None:
+        if issue is None:
             Http404("Issue does not exist, cannot comment")
 
         if len(replying_to_input) == 2:
@@ -2296,7 +2296,7 @@ def comment_on_issue(request, issue_pk):
 
             parent_comment = Comment.objects.filter(pk=replying_to_comment_id).first()
 
-            if parent_comment == None:
+            if parent_comment is None:
                 messages.error(request,"Parent comment doesn't exist.")
                 return redirect(f"/issue2/{issue_pk}")
 
@@ -2399,7 +2399,7 @@ def get_scoreboard(request):
         temp["closed"] = len(each.closed_issues)
         temp["modified"] = each.modified
         temp["logo"] = each.logo
-        if each.top_tester == None:
+        if each.top_tester is None:
             temp["top"] = "None"
         else:
             temp["top"] = each.top_tester.username
@@ -2598,15 +2598,15 @@ class ListHunts(TemplateView):
         if search.strip() != "":
             hunts = hunts.filter(Q(name__icontains=search))
 
-        if start_date != "" and start_date != None:
+        if start_date != "" and start_date is not None:
             start_date = datetime.strptime(start_date,"%m/%d/%Y").strftime("%Y-%m-%d %H:%M")
             hunts = hunts.filter(starts_on__gte=start_date)
         
-        if end_date != "" and end_date != None:
+        if end_date != "" and end_date is not None:
             end_date = datetime.strptime(end_date,"%m/%d/%Y").strftime("%Y-%m-%d %H:%M")
             hunts = hunts.filter(end_on__gte=end_date)
 
-        if domain != "Select Domain" and domain != None:
+        if domain != "Select Domain" and domain is not None:
             domain = Domain.objects.filter(id=domain).first()
             hunts = hunts.filter(domain=domain)
         
@@ -3518,7 +3518,7 @@ def contributors_view(request,*args,**kwargs):
             if str(i["id"])==contributor_id:
                 contributor = i
         
-        if contributor==None:
+        if contributor is None:
             return HttpResponseNotFound("Contributor not found")
         
         return render(request,"contributors_detail.html",context={"contributor":contributor})
@@ -3635,7 +3635,7 @@ def like_issue2(request, issue_pk):
 def subscribe_to_domains(request, pk):
 
     domain = Domain.objects.filter(pk=pk).first()
-    if domain == None:
+    if domain is None:
         return JsonResponse("ERROR", safe=False,status=400)
     
     already_subscribed = request.user.userprofile.subscribed_domains.filter(pk=domain.id).exists()


### PR DESCRIPTION
Make `== None` and `!= None` cases compliant with [PEP8](https://peps.python.org/pep-0008/#programming-recommendations):

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.


// Similar True/False comparisons update is on the way.