### PR TITLE
updated sidenav and added links from previous footer not present 

### DIFF
--- a/website/templates/includes/sidenav.html
+++ b/website/templates/includes/sidenav.html
@@ -112,7 +112,7 @@
                     <a href="{% url 'bltv' %}"><span class="text">BLTV</span></a>
                 </li>
             </ul>
-            <ul class="space-y-2 font-medium text-2xl mt-1">
+            <ul class="space-y-2 font-medium text-2xl mt-1 pb-10">
                 <li class="mb-[-6px] ms-[1px]">
                     <span class="font-bold text-[#AAA] text-[1.2rem] tracking-wide">MORE</span>
                 </li>
@@ -145,7 +145,7 @@
                     <div class="w-8 mr-4">
                         <i class="fa fa-code-fork" id="icon"></i>
                     </div>
-                    <a href="https://github.com/OWASP/BLT#readme" rel="noopener noreferrer"><span>Developers</span></a>
+                    <a href="https://github.com/OWASP/BLT#readme" rel="noopener noreferrer"><span>Dev Guides</span></a>
                 </li>
                 <li class="flex items-center p-2">
                     <div class="w-8 mr-4">
@@ -158,6 +158,12 @@
                         <i class="fa fa-star" id="icon"></i>
                     </div>
                     <a href="https://github.com/OWASP/BLT/releases" class="text"><span>Features</span></a>
+                </li>
+                <li class="flex items-center p-2">
+                    <div class="w-8 mr-4">
+                        <i class="fa fa-file-code-o" id="icon"></i>
+                    </div>
+                    <a href="https://blt.owasp.org/swagger/" class="text"><span>Developer API</span></a>
                 </li>
                 <li class="flex items-center p-2">
                     <div class="w-8 mr-4">


### PR DESCRIPTION
fixes #1933 

Most of the links from previous footer were already present in the sidenav added the developer API link that was missing.

![image](https://github.com/OWASP-BLT/BLT/assets/97180942/372b448a-f2b7-4668-a4fb-b092de39f2ee)
