### PR TITLE
company_id not setting while creating company

### DIFF
--- a/website/models.py
+++ b/website/models.py
@@ -62,6 +62,11 @@ class Company(models.Model):
 
     def __str__(self):
         return self.name
+    
+    def save(self, *args, **kwargs):
+        if not self.company_id:
+            self.company_id = str(uuid.uuid4())
+        super().save(*args, **kwargs)
 
 
 class Domain(models.Model):


### PR DESCRIPTION
While creating a company we are getting an issue of company_id is not unique which is because it is not getting set, this will give Integrity error in the code while making the requests.

Previously:

![Screenshot (99)](https://github.com/OWASP-BLT/BLT/assets/106571927/067a435e-ca32-4b13-9819-022b7f1f4cef)

Now:

![Screenshot (103)](https://github.com/OWASP-BLT/BLT/assets/106571927/924ec2c1-422c-49dd-a8af-421f947b90ff)
