### PR TITLE
Added endpoint for company leaderboard

### DIFF
--- a/website/api/views.py
+++ b/website/api/views.py
@@ -421,7 +421,7 @@ class LeaderboardApiViewSet(APIView):
         company_urls = (
             Issue.objects.values("domain")
             .annotate(issue_count=Count("domain"))
-            .order_by("-issue_count")
+            .order_by("-issue_count")[:100]
         )
 
         companies = []
@@ -430,8 +430,8 @@ class LeaderboardApiViewSet(APIView):
             company = Company.objects.filter(url=domain.url).first()
             serializer = CompanySerializer(company)
             companies.append({"company": serializer.data, "issue_count": url["issue_count"]})
-            if len(companies) >= 100:
-                break
+            # if len(companies) >= 100:
+            #     break
 
         return Response(companies)
 


### PR DESCRIPTION
Added endpoints to get a scoreboard/ leaderboard for the companies according to the total number of issues.
Will help in implementing and tracking the leaderboard for the companies in the application.

![Screenshot (116)](https://github.com/OWASP-BLT/BLT/assets/106571927/a17605ff-bd45-4fa4-9eea-a4955d290500)
