### PR TITLE
fix domain detections in create issue

### DIFF
--- a/company/views.py
+++ b/company/views.py
@@ -493,17 +493,20 @@ class AddDomainView(View):
             "facebook": request.POST.get("facebook_url", None),
         }
 
+        # Check the domain url and make it clean like if it's like "https://drive.google.com/drive/u/0/home" or "https://drive.google.com" it should be "drive.google.com"
+        if domain_data["url"]:
+            parsed_url = urlparse(domain_data["url"])
+            if parsed_url.hostname is None:
+                messages.error(request, "Invalid domain url")
+                return redirect("add_domain", id=id)
+            domain_data["url"] = parsed_url.netloc
+
         if domain_data["name"] is None:
             messages.error(request, "Enter domain name")
             return redirect("add_domain", id=id)
 
         if domain_data["url"] is None:
             messages.error(request, "Enter domain url")
-            return redirect("add_domain", id=id)
-
-        parsed_url = urlparse(domain_data["url"])
-        if parsed_url.hostname is None:
-            messages.error(request, "Invalid domain url")
             return redirect("add_domain", id=id)
 
         domain = (parsed_url.hostname).replace("www.", "")

--- a/company/views.py
+++ b/company/views.py
@@ -493,7 +493,6 @@ class AddDomainView(View):
             "facebook": request.POST.get("facebook_url", None),
         }
 
-        # Check the domain url and make it clean like if it's like "https://drive.google.com/drive/u/0/home" or "https://drive.google.com" it should be "drive.google.com"
         if domain_data["url"]:
             parsed_url = urlparse(domain_data["url"])
             if parsed_url.hostname is None:

--- a/website/views.py
+++ b/website/views.py
@@ -825,6 +825,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
         print("processing post for ip address: ", get_client_ip(request))
         # resolve domain
         url = request.POST.get("url").replace("www.", "").replace("https://", "")
+        print(url)
 
         request.POST._mutable = True
         request.POST.update(url=url)  # only domain.com will be stored in db
@@ -939,10 +940,9 @@ class IssueCreate(IssueBaseCreate, CreateView):
                     "report.html",
                     {"form": self.get_form(), "captcha_form": captcha_form},
                 )
-            clean_domain = (
-                obj.domain_name.replace("www.", "").replace("https://", "").replace("http://", "")
-            )
-            domain = Domain.objects.filter(name=clean_domain).first()
+            parsed_url = urlparse(obj.url)
+            clean_domain = parsed_url.netloc
+            domain = Domain.objects.filter(url=clean_domain).first()
 
             domain_exists = False if domain is None else True
 

--- a/website/views.py
+++ b/website/views.py
@@ -825,7 +825,6 @@ class IssueCreate(IssueBaseCreate, CreateView):
         print("processing post for ip address: ", get_client_ip(request))
         # resolve domain
         url = request.POST.get("url").replace("www.", "").replace("https://", "")
-        print(url)
 
         request.POST._mutable = True
         request.POST.update(url=url)  # only domain.com will be stored in db


### PR DESCRIPTION
### Issue:

Previously, the system incorrectly identified URLs with paths as new domains. For example, if "youtube.com" already existed in the database and a user submitted an issue with "youtube.com/home", the system treated "youtube.com/home" as a new domain, creating a duplicate domain object.

### Solution:

- **Domain Cleaning:** Implemented a function to extract the base domain from URLs, ensuring that "youtube.com" and "youtube.com/home" are recognized as the same domain.
- **Database Check:** Updated the domain checking mechanism to prevent the creation of duplicate domain objects for URLs with the same base domain.

### Changes Made:

- Added a `clean_domain` function to extract the base domain using `urlparse`.
- Updated the domain creation logic to check for existing domains using the cleaned domain value.

### Example:

- Before: "youtube.com" and "youtube.com/home" were treated as separate domains.
- After: Both URLs are recognized as "youtube.com", preventing duplicate entries.

### Request for Review:

@DonnieBLT, could you please review these changes for merging? 