### PR TITLE
Fixes #2589 - Update Setup instructions

### DIFF
--- a/Setup.md
+++ b/Setup.md
@@ -1,35 +1,37 @@
 # Setting up Development server
 
 - [Video on How to setup Project BLT](https://www.youtube.com/watch?v=IYBRVRfPCK8)
-  
 
 ## Setting Up Development Server using Docker-compose (Recommended)
 
 ### Install [Docker](https://docs.docker.com/get-docker/)
 
 ```sh
- # Move to project directory
+ # --- Move to project directory ---
  cd BLT
 
- # build the docker container
+ # --- build the docker container ---
  docker-compose build
- 
- # Run the docker container
+
+ # --- Run the docker container ---
  docker-compose up
 
- # Collect static files
- ### get container id
- docker ps
+ # --- Collect static files ---
 
  ### open container bash terminal
- docker exec -it <container id> /bin/bash
+ # `app` is the service name in docker-compose.yml
+ docker exec -it app /bin/bash
 
+ # Below commands are for container shell
  ### migrate SQL commands in the database file
  python manage.py migrate
 
  ### collect staticfiles
  python manage.py collectstatic
- 
+
+ # --- exit out of container shell ---
+ exit
+
 ```
 
 ## Setting Up Development Server using Vagrant
@@ -78,56 +80,42 @@ from the host machine.
 
 ## Setting Up Development Server using Python Virtual Environment
 
+### Setup Correct python version
+
+Current supported python version is `3.11.2`. It can be installed using any tool of choice like `asdf`, `pyenv`, `hatch`.
+For this guide, we are using `pyenv`. Install pyenv by following instructions in its [Github Repo](https://github.com/pyenv/pyenv?tab=readme-ov-file#installation)
+
 ```sh
+pyenv install 3.11.2
 
- # Install postgres on mac using brew
- brew install postgresql
-
- # Install postgres on ubuntu
- sudo apt-get install postgresql
-
- # Install pipenv on ubuntu
- sudo apt-get install pipenv
-
- # Install pipenv on mac
- pip install pipenv
-
- # Start virtual env
- pipenv install | pipenv shell
-
- # Move to project directory
- cd BLT
-
- # Create tables in the database
- python manage.py migrate
-
- # Load initial data
- python3 manage.py loaddata website/fixtures/initial_data.json
-
- # Create a super user
- python manage.py createsuperuser
-
- # Collect static files
- python manage.py collectstatic
-
- # Run the server
- python manage.py runserver
 ```
 
-### Alternative using Poetry
+Note: Project root folder already contains `.python-version`, so pyenv can recognize the local version to use for the current project.
+
+### Setup Virtual environment using poetry
+
+Ensure that `python -V` returns the correct python version for the project
+
 ```sh
+# --- Install postgres ---
+
+# Install postgres on mac
 brew install postgresql
 
 # Install postgres on ubuntu
 sudo apt-get install postgresql
 
+# --- Setup Virtual Environment ---
 # Install Poetry
 pip install poetry
 
+# Activate virtual environment
 poetry shell
 
+# Install required dependencies
 poetry install
 
+# --- Project setup ---
 # Create tables in the database
 python manage.py migrate
 


### PR DESCRIPTION
1. Update docker compose exec command to use service name instead of container id.
2. Remove setup instructions for pipenv because 
    - Project doesn't have a Pipfile that can be used by pipenv to create a virtual environment. 
    - Poetry serves the same purpose, so no need to keep to environment manager.
3. Added instructions to use correct python version using pyenv


closes #2589 