### PR TITLE
Move .env.examples from /blt/blt to the project root directory and update the location of .env to root in settings.py

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,9 @@ LANGCHAIN_API_KEY=langchain_api_key
 LANGCHAIN_TRACING_V2=true
 LANGCHAIN_PROJECT=default
 LANGCHAIN_ENDPOINT="https://api.smith.langchain.com"
+
+#Database URL
+DATABASE_URL=postgres://user:password@localhost:5432/dbname
+
+#Sentry DSN
+SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0

--- a/blt/settings.py
+++ b/blt/settings.py
@@ -16,8 +16,8 @@ import environ
 from django.utils.translation import gettext_lazy as _
 
 env = environ.Env()
-# reading .env file
-environ.Env.read_env()
+# reading .env file from parent directory
+environ.Env.read_env(os.path.join(os.path.dirname(os.path.dirname(__file__)), ".env"))
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))


### PR DESCRIPTION
Fixes #2793 

Moved the .env.example file to the project root directory and updated the location for .env in blt/settings.py
Also added examples for DATABASE_URL and SENTRY_DSN
