### PR TITLE
Updated GSOC PAGE

### DIFF
--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -57,7 +57,7 @@
         font-size: 1.1rem;
         }
         .mentor-list li strong {
-        font-weight: 700;
+        font-weight: 700;git
         color: #333;
         }
         .link-text {
@@ -67,6 +67,8 @@
         margin-bottom: 0.25rem;  /* Reduced from 1rem */
         }
         .blog-links {
+        display: flex;
+        gap: 1px;
         margin-bottom: 0.25rem;
         }
         .blog-links .link-text {
@@ -192,7 +194,7 @@
         </ul>
         </div>
         <h1 class="text-[3rem] m-4">Blogs By Previous GSOC Contributors:</h1>
-        <div class="blog-links" style="display: flex; gap: 1px;">
+        <div class="blog-links">
         <a href="https://medium.com/@shirshjain/my-gsoc24-experience-at-owasp-b341e581a5d0"
            target="_blank">
             <div class="link-text">
@@ -206,7 +208,7 @@
             </div>
         </a>
         </div>
-        <div class="blog-links" style="display: flex; gap: 1px;">
+        <div class="blog-links">
         <a href="https://medium.com/@justary27/my-gsoc22-voyage-beginning-4296df5af625"
            target="_blank">
             <div class="link-text">
@@ -220,7 +222,7 @@
             </div>
         </a>
         </div>
-        <div class="blog-links" style="display: flex; gap: 1px;">
+        <div class="blog-links">
         <a href="https://gist.github.com/AtmegaBuzz/512a85827b5cc993e35c274dcbada669"
            target="_blank">
             <div class="link-text">
@@ -252,7 +254,7 @@
                 Chakshu Gupta's GSOC journey with OWASP Honeypot <i class="fa-solid fa-link"></i>
             </div>
         </a>
-        <div class="blog-links" style="display: flex; gap: 1px;">
+        <div class="blog-links">
         <a href="https://bishaldas.hashnode.dev/gsoc-2024-a-summer-of-learning-coding-and-growth"
            target="_blank">
             <div class="link-text">

--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -57,7 +57,7 @@
         font-size: 1.1rem;
         }
         .mentor-list li strong {
-        font-weight: 700;git
+        font-weight: 700;
         color: #333;
         }
         .link-text {
@@ -77,37 +77,44 @@
     </style>
     <div class="container">
         <div class="content-section">
-           <h1 class="text-[3rem] m-4">What is GSOC?</h1>
-           <p>The <a href="https://summerofcode.withgoogle.com/" class="gsoc-link">Google Summer of Code program</a> ("GSoC") is designed to encourage student participation in open source development. Through GSoC, accepted student applicants will be paired with OWASP mentors that will guide them through their coding tasks.</p>
-           <p>Benefits to students include:</p>
-           <ul class="benefits-list">
-           <li>Gaining exposure to real-world software development scenarios</li>
-           <li>An opportunity for employment in areas related to their academic pursuits</li>
-           <li>Google will be offering successful student contributors a stipend, enabling them to focus on their coding projects for the duration of GSoC.</li>
-           </ul>
-           <p>This program is done completely online. Students and mentors from more than 100 countries have participated in past years.</p>
-        </div> 
-
+            <h1 class="text-[3rem] m-4">What is GSOC?</h1>
+            <p>
+                The <a href="https://summerofcode.withgoogle.com/" class="gsoc-link">Google Summer of Code program</a> ("GSoC") is designed to encourage student participation in open source development. Through GSoC, accepted student applicants will be paired with OWASP mentors that will guide them through their coding tasks.
+            </p>
+            <p>Benefits to students include:</p>
+            <ul class="benefits-list">
+                <li>Gaining exposure to real-world software development scenarios</li>
+                <li>An opportunity for employment in areas related to their academic pursuits</li>
+                <li>
+                    Google will be offering successful student contributors a stipend, enabling them to focus on their coding projects for the duration of GSoC.
+                </li>
+            </ul>
+            <p>
+                This program is done completely online. Students and mentors from more than 100 countries have participated in past years.
+            </p>
+        </div>
         <h1 class="text-[3rem] m-4">OWASP BLT's contributions and partnership with GSOC:</h1>
         <ul class="benefits-list">
-        <li>OWASP is an open community dedicated to enabling organizations to conceive, develop, acquire, operate, and maintain applications that can be trusted. OWASP has been an active participant in the Google Summer of Code program, providing students with the opportunity to contribute to various OWASP projects.</li>
-        <li>OWASP BLT (Bug Logging Tool) has been participating in the Google Summer of Code program for the past 5 consecutive years, from 2020 to 2024. OWASP BLT is an open-source platform dedicated to making the internet safer through community-driven bug reporting and collaboration. Users can report bugs, track issues, and collaborate with organizations to enhance security measures.</li>
-        <li>All students currently enrolled in an accredited institution are welcome to participate in the Google Summer of Code program, hopefully along with the OWASP Foundation.</li>
-        <a href="https://github.com/OWASP-BLT/BLT/issues/2916"
-           target="_blank">
-            <div class="link-text">
-                GSOC 2025 Leadarboard <i class="fa-solid fa-link"></i>
-            </div>
-        </a>
-        <a href="https://github.com/OWASP-BLT/BLT/issues/2384"
-           target="_blank">
-            <div class="link-text">
-                GSOC 2024 Leadarboard <i class="fa-solid fa-link"></i>
-            </div>
-        </a>
+            <li>
+                OWASP is an open community dedicated to enabling organizations to conceive, develop, acquire, operate, and maintain applications that can be trusted. OWASP has been an active participant in the Google Summer of Code program, providing students with the opportunity to contribute to various OWASP projects.
+            </li>
+            <li>
+                OWASP BLT (Bug Logging Tool) has been participating in the Google Summer of Code program for the past 5 consecutive years, from 2020 to 2024. OWASP BLT is an open-source platform dedicated to making the internet safer through community-driven bug reporting and collaboration. Users can report bugs, track issues, and collaborate with organizations to enhance security measures.
+            </li>
+            <li>
+                All students currently enrolled in an accredited institution are welcome to participate in the Google Summer of Code program, hopefully along with the OWASP Foundation.
+            </li>
+            <a href="https://github.com/OWASP-BLT/BLT/issues/2916" target="_blank">
+                <div class="link-text">
+                    GSOC 2025 Leadarboard <i class="fa-solid fa-link"></i>
+                </div>
+            </a>
+            <a href="https://github.com/OWASP-BLT/BLT/issues/2384" target="_blank">
+                <div class="link-text">
+                    GSOC 2024 Leadarboard <i class="fa-solid fa-link"></i>
+                </div>
+            </a>
         </ul>
-        
-
         <h1 class="text-[3rem] m-4">GSOC Previous Projects:</h1>
         <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2024ideas"
            target="_blank">
@@ -116,28 +123,28 @@
             </div>
         </a>
         <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2023ideas"
-        target="_blank">
-         <div class="link-text">
-             GSOC Project Ideas 2023 <i class="fa-solid fa-link"></i>
-         </div>
+           target="_blank">
+            <div class="link-text">
+                GSOC Project Ideas 2023 <i class="fa-solid fa-link"></i>
+            </div>
         </a>
         <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2022ideas"
-        target="_blank">
-         <div class="link-text">
-             GSOC Project Ideas 2022 <i class="fa-solid fa-link"></i>
-         </div>
+           target="_blank">
+            <div class="link-text">
+                GSOC Project Ideas 2022 <i class="fa-solid fa-link"></i>
+            </div>
         </a>
         <a href=" https://owasp.org/www-community/initiatives/gsoc/gsoc2021ideas"
-        target="_blank">
-         <div class="link-text">
-             GSOC Project Ideas 2021 <i class="fa-solid fa-link"></i>
-         </div>
+           target="_blank">
+            <div class="link-text">
+                GSOC Project Ideas 2021 <i class="fa-solid fa-link"></i>
+            </div>
         </a>
         <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2020ideas"
-        target="_blank">
-         <div class="link-text">
-             GSOC Project Ideas 2020 <i class="fa-solid fa-link"></i>
-         </div>
+           target="_blank">
+            <div class="link-text">
+                GSOC Project Ideas 2020 <i class="fa-solid fa-link"></i>
+            </div>
         </a>
         <a href="https://github.com/orgs/OWASP-BLT/projects?query=is%3Aopen"
            target="_blank">
@@ -147,94 +154,99 @@
         </a>
         <h1 class="text-[3rem] m-4">Past GSOC Events:</h1>
         <div class="archive-section">
-        <a href="https://summerofcode.withgoogle.com/archive/2023/organizations/owasp-foundation"
-           target="_blank">
-            <div class="link-text">
-                2023 GSOC Archive <i class="fa-solid fa-link"></i>
-            </div>
-        </a>
-        <ul class="mentor-list">
-            <li><strong>Mentors:</strong>Abraham Aranguren, Aryan Prasad, Aryan Ranjan, Ben de Haan, Björn Kimminich, Christian Folini, DonnieBLT, fzipitria, Jannik Hollenbach, José Carlos Chávez, Mrigank Anand, Rick M, ShubhamPalriwala, Simon Bennetts, thc202, Timo Pagel, Viyat
-            </li>
-        </ul>
+            <a href="https://summerofcode.withgoogle.com/archive/2023/organizations/owasp-foundation"
+               target="_blank">
+                <div class="link-text">
+                    2023 GSOC Archive <i class="fa-solid fa-link"></i>
+                </div>
+            </a>
+            <ul class="mentor-list">
+                <li>
+                    <strong>Mentors:</strong>Abraham Aranguren, Aryan Prasad, Aryan Ranjan, Ben de Haan, Björn Kimminich, Christian Folini, DonnieBLT, fzipitria, Jannik Hollenbach, José Carlos Chávez, Mrigank Anand, Rick M, ShubhamPalriwala, Simon Bennetts, thc202, Timo Pagel, Viyat
+                </li>
+            </ul>
         </div>
         <div class="archive-section">
-        <a href="https://summerofcode.withgoogle.com/archive/2022/organizations/owasp-foundation"
-           target="_blank">
-            <div class="link-text">
-                2022 GSOC Archive <i class="fa-solid fa-link"></i>
-            </div>
-        </a>
-        <ul class="mentor-list">
-            <li><strong>Mentors:</strong> Abraham Aranguren, Ade Yoseman Putra, Ankit Choudhary, Björn Kimminich, Dhiren Serai, Franziska, fzipitria, Glenn Ten Cate, Jannik Hollenbach, Rejah Rehim, Rick M, Saeed Dehqan, Sam Stepanyan, Simon Bennetts, Sparsh Agrawal, thc202, Timo Pagel, Viyat
-            </li>
-        </ul>
+            <a href="https://summerofcode.withgoogle.com/archive/2022/organizations/owasp-foundation"
+               target="_blank">
+                <div class="link-text">
+                    2022 GSOC Archive <i class="fa-solid fa-link"></i>
+                </div>
+            </a>
+            <ul class="mentor-list">
+                <li>
+                    <strong>Mentors:</strong> Abraham Aranguren, Ade Yoseman Putra, Ankit Choudhary, Björn Kimminich, Dhiren Serai, Franziska, fzipitria, Glenn Ten Cate, Jannik Hollenbach, Rejah Rehim, Rick M, Saeed Dehqan, Sam Stepanyan, Simon Bennetts, Sparsh Agrawal, thc202, Timo Pagel, Viyat
+                </li>
+            </ul>
         </div>
         <div class="archive-section">
-        <a href="https://summerofcode.withgoogle.com/archive/2021/organizations/owasp-foundation"
-           target="_blank">
-            <div class="link-text">
-                2021 GSOC Archive <i class="fa-solid fa-link"></i>
-            </div>
-        </a>
-        <ul class="mentor-list">
-            <li><strong>Mentors:</strong> 8f040, Abe, Abraham Aranguren, Ade Yoseman Putra, Ali Razmjoo Qalaei, Anshul Singhal, Ashrith N Shetty, Björn Kimminich, Damien Carol, Dhiren Devinder Serai, Glenn ten Cate, Jannik Hollenbach, madchap, Mohit Sharma-2, Rejah Rehim, Riccardo Cate, Rick M, Saeed Dehqan-1, Sam Stepanyan, Simon Bennetts, Sourav Badami, thc202</li>
-        </ul>
+            <a href="https://summerofcode.withgoogle.com/archive/2021/organizations/owasp-foundation"
+               target="_blank">
+                <div class="link-text">
+                    2021 GSOC Archive <i class="fa-solid fa-link"></i>
+                </div>
+            </a>
+            <ul class="mentor-list">
+                <li>
+                    <strong>Mentors:</strong> 8f040, Abe, Abraham Aranguren, Ade Yoseman Putra, Ali Razmjoo Qalaei, Anshul Singhal, Ashrith N Shetty, Björn Kimminich, Damien Carol, Dhiren Devinder Serai, Glenn ten Cate, Jannik Hollenbach, madchap, Mohit Sharma-2, Rejah Rehim, Riccardo Cate, Rick M, Saeed Dehqan-1, Sam Stepanyan, Simon Bennetts, Sourav Badami, thc202
+                </li>
+            </ul>
         </div>
         <div class="archive-section">
-        <a href="https://summerofcode.withgoogle.com/archive/2020/organizations/owasp-foundation"
-           target="_blank">
-            <div class="link-text">
-                2020 GSOC Archive <i class="fa-solid fa-link"></i>
-            </div>
-        </a>
-        <ul class="mentor-list">
-            <li><strong>Mentors:</strong> Abe, Abraham Aranguren, Ade Yoseman Putra, Adrian Winckles, Ali Razmjoo Qalaei, Björn Kimminich, Felipe Zipitria, Glenn ten Cate, Jannik Hollenbach, Mohit Sharma, Rejah Rehim A A, Rejah Rehim, Ricardo Pereira, Riccardo ten Cate, Rick M, S, securestep9, Simon Bennetts, Soham Marik, souravbadami, spyros, Sri Harsha G, Timo Pagel, Viyat Bhalodia
-            </li>
-        </ul>
+            <a href="https://summerofcode.withgoogle.com/archive/2020/organizations/owasp-foundation"
+               target="_blank">
+                <div class="link-text">
+                    2020 GSOC Archive <i class="fa-solid fa-link"></i>
+                </div>
+            </a>
+            <ul class="mentor-list">
+                <li>
+                    <strong>Mentors:</strong> Abe, Abraham Aranguren, Ade Yoseman Putra, Adrian Winckles, Ali Razmjoo Qalaei, Björn Kimminich, Felipe Zipitria, Glenn ten Cate, Jannik Hollenbach, Mohit Sharma, Rejah Rehim A A, Rejah Rehim, Ricardo Pereira, Riccardo ten Cate, Rick M, S, securestep9, Simon Bennetts, Soham Marik, souravbadami, spyros, Sri Harsha G, Timo Pagel, Viyat Bhalodia
+                </li>
+            </ul>
         </div>
         <h1 class="text-[3rem] m-4">Blogs By Previous GSOC Contributors:</h1>
         <div class="blog-links">
-        <a href="https://medium.com/@shirshjain/my-gsoc24-experience-at-owasp-b341e581a5d0"
-           target="_blank">
-            <div class="link-text">
-                Shirish Jain's GSOC Journey with OWASP BLT <i class="fa-solid fa-link"></i>
-            </div>
-        </a>
-        <a href="https://blt.owasp.org/contributors/?contributor=37"
-           target="_blank">
-            <div class="link-text">
-              Shirish Jain's Profile <i class="fa fa-user fa-fw"></i>
-            </div>
-        </a>
+            <a href="https://medium.com/@shirshjain/my-gsoc24-experience-at-owasp-b341e581a5d0"
+               target="_blank">
+                <div class="link-text">
+                    Shirish Jain's GSOC Journey with OWASP BLT <i class="fa-solid fa-link"></i>
+                </div>
+            </a>
+            <a href="https://blt.owasp.org/contributors/?contributor=37"
+               target="_blank">
+                <div class="link-text">
+                    Shirish Jain's Profile <i class="fa fa-user fa-fw"></i>
+                </div>
+            </a>
         </div>
         <div class="blog-links">
-        <a href="https://medium.com/@justary27/my-gsoc22-voyage-beginning-4296df5af625"
-           target="_blank">
-            <div class="link-text">
-                Aryan Ranjan's GSoC Voyage <i class="fa-solid fa-link"></i>
-            </div>
-        </a>
-        <a href="https://blt.owasp.org/contributors/?contributor=1"
-           target="_blank">
-            <div class="link-text">
-              Aryan Ranjan's Profile <i class="fa fa-user fa-fw"></i>
-            </div>
-        </a>
+            <a href="https://medium.com/@justary27/my-gsoc22-voyage-beginning-4296df5af625"
+               target="_blank">
+                <div class="link-text">
+                    Aryan Ranjan's GSoC Voyage <i class="fa-solid fa-link"></i>
+                </div>
+            </a>
+            <a href="https://blt.owasp.org/contributors/?contributor=1"
+               target="_blank">
+                <div class="link-text">
+                    Aryan Ranjan's Profile <i class="fa fa-user fa-fw"></i>
+                </div>
+            </a>
         </div>
         <div class="blog-links">
-        <a href="https://gist.github.com/AtmegaBuzz/512a85827b5cc993e35c274dcbada669"
-           target="_blank">
-            <div class="link-text">
-                Swapnil Shinde's OWASP BLT Report <i class="fa-solid fa-link"></i>
-            </div>
-        </a>
-        <a href="https://blt.owasp.org/contributors/?contributor=3"
-           target="_blank">
-            <div class="link-text">
-              Swapnil Shinde's Profile <i class="fa fa-user fa-fw"></i>
-            </div>
-        </a>
+            <a href="https://gist.github.com/AtmegaBuzz/512a85827b5cc993e35c274dcbada669"
+               target="_blank">
+                <div class="link-text">
+                    Swapnil Shinde's OWASP BLT Report <i class="fa-solid fa-link"></i>
+                </div>
+            </a>
+            <a href="https://blt.owasp.org/contributors/?contributor=3"
+               target="_blank">
+                <div class="link-text">
+                    Swapnil Shinde's Profile <i class="fa fa-user fa-fw"></i>
+                </div>
+            </a>
         </div>
         <a href="https://medium.com/@shubhampalriwala/google-summer-of-code-journey-with-owasp-juice-shop-c1ca15c8e170"
            target="_blank">
@@ -255,18 +267,18 @@
             </div>
         </a>
         <div class="blog-links">
-        <a href="https://bishaldas.hashnode.dev/gsoc-2024-a-summer-of-learning-coding-and-growth"
-           target="_blank">
-            <div class="link-text">
-                Bishal Das's GSOC Learning journey with OWASP BLT <i class="fa-solid fa-link"></i>
-            </div>
-        </a>
-        <a href="https://blt.owasp.org/contributors/?contributor=5"
-           target="_blank">
-            <div class="link-text">
-              Bishal Das's Profile <i class="fa fa-user fa-fw"></i>
-            </div>
-        </a>
+            <a href="https://bishaldas.hashnode.dev/gsoc-2024-a-summer-of-learning-coding-and-growth"
+               target="_blank">
+                <div class="link-text">
+                    Bishal Das's GSOC Learning journey with OWASP BLT <i class="fa-solid fa-link"></i>
+                </div>
+            </a>
+            <a href="https://blt.owasp.org/contributors/?contributor=5"
+               target="_blank">
+                <div class="link-text">
+                    Bishal Das's Profile <i class="fa fa-user fa-fw"></i>
+                </div>
+            </a>
         </div>
         <a href="https://medium.com/@ChGDream/my-google-summer-of-code-2020-journey-with-owasp-b772c3e67c3f"
            target="_blank">

--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -7,23 +7,135 @@
             height: calc(100vh - 90px);
             display: flex;
             flex-direction: column;
+            max-width: 1200px;
+            padding: 0 2rem;
         }
         .link-text {
             font-weight: bold;
             transition: color 0.3s ease;
             margin-left: 20px;
+            margin-bottom: 1rem;
         }
         .link-text:hover {
             color: red; /* Assuming 'text-danger' is red; adjust as needed */
         }
+        .gsoc-link:hover {
+        color: rgb(255, 0, 0);
+        text-decoration: underline;
+        font-weight: 500;
+        }
+        .gsoc-link:hover {
+            color: red;
+        }
+        .content-section {
+        margin-bottom: 1.5rem;
+        }
+        .section-title {
+        font-size: 2.5rem;
+        margin-bottom: 1.5rem;
+        color: #333;
+        }
+        .section-text {
+        font-size: 1.1rem;
+        line-height: 1.6;
+        margin-bottom: 1.5rem;
+        }
+        .benefits-list {
+        list-style-type: disc;
+        margin-left: 1rem;
+        margin-bottom: 1.5rem;
+        }
+        .benefits-list li {
+        margin-bottom: 0.1rem;
+        line-height: 1.5;
+        }
+        .mentor-list {
+        list-style-type: disc;
+        margin-left: 3rem;
+        margin-top: 0.25rem;  /* Reduced from 0.5rem */
+        color: #666;
+        font-size: 1.1rem;
+        }
+        .mentor-list li strong {
+        font-weight: 700;
+        color: #333;
+        }
+        .link-text {
+        font-weight: bold;
+        transition: color 0.3s ease;
+        margin-left: 20px;
+        margin-bottom: 0.25rem;  /* Reduced from 1rem */
+        }
+        .blog-links {
+        margin-bottom: 0.25rem;
+        }
+        .blog-links .link-text {
+        margin-bottom: 0.25rem;
+        }
     </style>
     <div class="container">
-        <h1 class="text-[3rem] m-4">GSOC Links:</h1>
+        <div class="content-section">
+           <h1 class="text-[3rem] m-4">What is GSOC?</h1>
+           <p>The <a href="https://summerofcode.withgoogle.com/" class="gsoc-link">Google Summer of Code program</a> ("GSoC") is designed to encourage student participation in open source development. Through GSoC, accepted student applicants will be paired with OWASP mentors that will guide them through their coding tasks.</p>
+           <p>Benefits to students include:</p>
+           <ul class="benefits-list">
+           <li>Gaining exposure to real-world software development scenarios</li>
+           <li>An opportunity for employment in areas related to their academic pursuits</li>
+           <li>Google will be offering successful student contributors a stipend, enabling them to focus on their coding projects for the duration of GSoC.</li>
+           </ul>
+           <p>This program is done completely online. Students and mentors from more than 100 countries have participated in past years.</p>
+        </div> 
+
+        <h1 class="text-[3rem] m-4">OWASP BLT's contributions and partnership with GSOC:</h1>
+        <ul class="benefits-list">
+        <li>OWASP is an open community dedicated to enabling organizations to conceive, develop, acquire, operate, and maintain applications that can be trusted. OWASP has been an active participant in the Google Summer of Code program, providing students with the opportunity to contribute to various OWASP projects.</li>
+        <li>OWASP BLT (Bug Logging Tool) has been participating in the Google Summer of Code program for the past 5 consecutive years, from 2020 to 2024. OWASP BLT is an open-source platform dedicated to making the internet safer through community-driven bug reporting and collaboration. Users can report bugs, track issues, and collaborate with organizations to enhance security measures.</li>
+        <li>All students currently enrolled in an accredited institution are welcome to participate in the Google Summer of Code program, hopefully along with the OWASP Foundation.</li>
+        <a href="https://github.com/OWASP-BLT/BLT/issues/2916"
+           target="_blank">
+            <div class="link-text">
+                GSOC 2025 Leadarboard <i class="fa-solid fa-link"></i>
+            </div>
+        </a>
+        <a href="https://github.com/OWASP-BLT/BLT/issues/2384"
+           target="_blank">
+            <div class="link-text">
+                GSOC 2024 Leadarboard <i class="fa-solid fa-link"></i>
+            </div>
+        </a>
+        </ul>
+        
+
+        <h1 class="text-[3rem] m-4">GSOC Previous Projects:</h1>
         <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2024ideas"
            target="_blank">
             <div class="link-text">
                 GSOC Project Ideas 2024 <i class="fa-solid fa-link"></i>
             </div>
+        </a>
+        <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2023ideas"
+        target="_blank">
+         <div class="link-text">
+             GSOC Project Ideas 2023 <i class="fa-solid fa-link"></i>
+         </div>
+        </a>
+        <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2022ideas"
+        target="_blank">
+         <div class="link-text">
+             GSOC Project Ideas 2022 <i class="fa-solid fa-link"></i>
+         </div>
+        </a>
+        <a href=" https://owasp.org/www-community/initiatives/gsoc/gsoc2021ideas"
+        target="_blank">
+         <div class="link-text">
+             GSOC Project Ideas 2021 <i class="fa-solid fa-link"></i>
+         </div>
+        </a>
+        <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2020ideas"
+        target="_blank">
+         <div class="link-text">
+             GSOC Project Ideas 2020 <i class="fa-solid fa-link"></i>
+         </div>
         </a>
         <a href="https://github.com/orgs/OWASP-BLT/projects?query=is%3Aopen"
            target="_blank">
@@ -32,49 +144,96 @@
             </div>
         </a>
         <h1 class="text-[3rem] m-4">Past GSOC Events:</h1>
+        <div class="archive-section">
         <a href="https://summerofcode.withgoogle.com/archive/2023/organizations/owasp-foundation"
            target="_blank">
             <div class="link-text">
                 2023 GSOC Archive <i class="fa-solid fa-link"></i>
             </div>
         </a>
+        <ul class="mentor-list">
+            <li><strong>Mentors:</strong>Abraham Aranguren, Aryan Prasad, Aryan Ranjan, Ben de Haan, Björn Kimminich, Christian Folini, DonnieBLT, fzipitria, Jannik Hollenbach, José Carlos Chávez, Mrigank Anand, Rick M, ShubhamPalriwala, Simon Bennetts, thc202, Timo Pagel, Viyat
+            </li>
+        </ul>
+        </div>
+        <div class="archive-section">
         <a href="https://summerofcode.withgoogle.com/archive/2022/organizations/owasp-foundation"
            target="_blank">
             <div class="link-text">
                 2022 GSOC Archive <i class="fa-solid fa-link"></i>
             </div>
         </a>
+        <ul class="mentor-list">
+            <li><strong>Mentors:</strong> Abraham Aranguren, Ade Yoseman Putra, Ankit Choudhary, Björn Kimminich, Dhiren Serai, Franziska, fzipitria, Glenn Ten Cate, Jannik Hollenbach, Rejah Rehim, Rick M, Saeed Dehqan, Sam Stepanyan, Simon Bennetts, Sparsh Agrawal, thc202, Timo Pagel, Viyat
+            </li>
+        </ul>
+        </div>
+        <div class="archive-section">
         <a href="https://summerofcode.withgoogle.com/archive/2021/organizations/owasp-foundation"
            target="_blank">
             <div class="link-text">
                 2021 GSOC Archive <i class="fa-solid fa-link"></i>
             </div>
         </a>
+        <ul class="mentor-list">
+            <li><strong>Mentors:</strong> 8f040, Abe, Abraham Aranguren, Ade Yoseman Putra, Ali Razmjoo Qalaei, Anshul Singhal, Ashrith N Shetty, Björn Kimminich, Damien Carol, Dhiren Devinder Serai, Glenn ten Cate, Jannik Hollenbach, madchap, Mohit Sharma-2, Rejah Rehim, Riccardo Cate, Rick M, Saeed Dehqan-1, Sam Stepanyan, Simon Bennetts, Sourav Badami, thc202</li>
+        </ul>
+        </div>
+        <div class="archive-section">
         <a href="https://summerofcode.withgoogle.com/archive/2020/organizations/owasp-foundation"
            target="_blank">
             <div class="link-text">
                 2020 GSOC Archive <i class="fa-solid fa-link"></i>
             </div>
         </a>
+        <ul class="mentor-list">
+            <li><strong>Mentors:</strong> Abe, Abraham Aranguren, Ade Yoseman Putra, Adrian Winckles, Ali Razmjoo Qalaei, Björn Kimminich, Felipe Zipitria, Glenn ten Cate, Jannik Hollenbach, Mohit Sharma, Rejah Rehim A A, Rejah Rehim, Ricardo Pereira, Riccardo ten Cate, Rick M, S, securestep9, Simon Bennetts, Soham Marik, souravbadami, spyros, Sri Harsha G, Timo Pagel, Viyat Bhalodia
+            </li>
+        </ul>
+        </div>
         <h1 class="text-[3rem] m-4">Blogs By Previous GSOC Contributors:</h1>
+        <div class="blog-links" style="display: flex; gap: 1px;">
         <a href="https://medium.com/@shirshjain/my-gsoc24-experience-at-owasp-b341e581a5d0"
            target="_blank">
             <div class="link-text">
                 Shirish Jain's GSOC Journey with OWASP BLT <i class="fa-solid fa-link"></i>
             </div>
         </a>
+        <a href="https://blt.owasp.org/contributors/?contributor=37"
+           target="_blank">
+            <div class="link-text">
+              Shirish Jain's Profile <i class="fa fa-user fa-fw"></i>
+            </div>
+        </a>
+        </div>
+        <div class="blog-links" style="display: flex; gap: 1px;">
         <a href="https://medium.com/@justary27/my-gsoc22-voyage-beginning-4296df5af625"
            target="_blank">
             <div class="link-text">
                 Aryan Ranjan's GSoC Voyage <i class="fa-solid fa-link"></i>
             </div>
         </a>
+        <a href="https://blt.owasp.org/contributors/?contributor=1"
+           target="_blank">
+            <div class="link-text">
+              Aryan Ranjan's Profile <i class="fa fa-user fa-fw"></i>
+            </div>
+        </a>
+        </div>
+        <div class="blog-links" style="display: flex; gap: 1px;">
         <a href="https://gist.github.com/AtmegaBuzz/512a85827b5cc993e35c274dcbada669"
            target="_blank">
             <div class="link-text">
                 Swapnil Shinde's OWASP BLT Report <i class="fa-solid fa-link"></i>
             </div>
         </a>
+        <a href="https://blt.owasp.org/contributors/?contributor=3"
+           target="_blank">
+            <div class="link-text">
+              Swapnil Shinde's Profile <i class="fa fa-user fa-fw"></i>
+            </div>
+        </a>
+        </div>
         <a href="https://medium.com/@shubhampalriwala/google-summer-of-code-journey-with-owasp-juice-shop-c1ca15c8e170"
            target="_blank">
             <div class="link-text">
@@ -85,6 +244,32 @@
            target="_blank">
             <div class="link-text">
                 Akshay Behl's GSOC Journey with OWASP Nettacker <i class="fa-solid fa-link"></i>
+            </div>
+        </a>
+        <a href="https://medium.com/@ChGDream/my-google-summer-of-code-2020-journey-with-owasp-b772c3e67c3f"
+           target="_blank">
+            <div class="link-text">
+                Chakshu Gupta's GSOC journey with OWASP Honeypot <i class="fa-solid fa-link"></i>
+            </div>
+        </a>
+        <div class="blog-links" style="display: flex; gap: 1px;">
+        <a href="https://bishaldas.hashnode.dev/gsoc-2024-a-summer-of-learning-coding-and-growth"
+           target="_blank">
+            <div class="link-text">
+                Bishal Das's GSOC Learning journey with OWASP BLT <i class="fa-solid fa-link"></i>
+            </div>
+        </a>
+        <a href="https://blt.owasp.org/contributors/?contributor=5"
+           target="_blank">
+            <div class="link-text">
+              Bishal Das's Profile <i class="fa fa-user fa-fw"></i>
+            </div>
+        </a>
+        </div>
+        <a href="https://medium.com/@ChGDream/my-google-summer-of-code-2020-journey-with-owasp-b772c3e67c3f"
+           target="_blank">
+            <div class="link-text">
+                Rishabh Keshan's GSOC Web3 journey with OWASP Juice Shop <i class="fa-solid fa-link"></i>
             </div>
         </a>
     </div>

--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -106,12 +106,12 @@
             </li>
             <a href="https://github.com/OWASP-BLT/BLT/issues/2916" target="_blank">
                 <div class="link-text">
-                    GSOC 2025 Leadarboard <i class="fa-solid fa-link"></i>
+                    GSOC 2025 Leaderboard <i class="fa-solid fa-link"></i>
                 </div>
             </a>
             <a href="https://github.com/OWASP-BLT/BLT/issues/2384" target="_blank">
                 <div class="link-text">
-                    GSOC 2024 Leadarboard <i class="fa-solid fa-link"></i>
+                    GSOC 2024 Leaderboard <i class="fa-solid fa-link"></i>
                 </div>
             </a>
         </ul>


### PR DESCRIPTION
 added brief description about GSOC, BLT's presence and contributions, added GSOC Leaderboard links, added previous year project ideas, added list of mentors for each year, added more blogs by contributors along with their profile url.
<img width="1440" alt="Screenshot 2024-11-15 at 3 47 42 AM" src="https://github.com/user-attachments/assets/b490b18f-ad15-489b-9706-f6b2af319ad2">
<img width="1440" alt="Screenshot 2024-11-15 at 3 48 13 AM" src="https://github.com/user-attachments/assets/aaa3d214-bb9a-4080-81f5-40ea97c49dbc">
