### PR TITLE
Fix: Remove login modal and update Daily Status Report modal behavior

### DIFF
--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -188,7 +188,6 @@
         </script>
         <script type="text/javascript">
             document.addEventListener('DOMContentLoaded', function() {
-
             // Check if the modal exists in the DOM
             const modal = document.getElementById('cardModalDailyStatus');
             if (!modal) {
@@ -280,8 +279,6 @@
                     });
                 });
             }
-
-           
         });
         </script>
     </html>

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -188,6 +188,7 @@
         </script>
         <script type="text/javascript">
             document.addEventListener('DOMContentLoaded', function() {
+
             // Check if the modal exists in the DOM
             const modal = document.getElementById('cardModalDailyStatus');
             if (!modal) {
@@ -195,7 +196,7 @@
             }
 
             const closeButton = modal.querySelector('.close-button');
-            const loginForm = document.getElementById('loginForm');
+            const openCheckInButton = document.getElementById('openCheckIn');
             const checkInForm = document.getElementById('checkInForm');
 
             // Function to check if form was submitted today
@@ -235,10 +236,10 @@
                 }
             });
 
-            // Show modal if not submitted today also the page should be the home page
-            if (!isFormSubmittedToday() && window.location.pathname === '/') {
-                showModal();
-            }
+            // Event listener to open modal when clicking the openCheckIn button           
+            if (openCheckInButton) {
+                 openCheckInButton.addEventListener('click', showModal);
+             }
 
             // Handle check-in form submission with AJAX
             if (checkInForm) {
@@ -280,12 +281,7 @@
                 });
             }
 
-            // Event listener to open modal when clicking the openCheckIn button
-            const openCheckInButton = document.getElementById('openCheckIn');
-            console.log(openCheckInButton);
-            if (openCheckInButton) {
-                openCheckInButton.addEventListener('click', showModal);
-            }
+           
         });
         </script>
     </html>

--- a/website/templates/includes/checkInModal.html
+++ b/website/templates/includes/checkInModal.html
@@ -4,13 +4,10 @@
     <div class="modal-card">
         <div class="modal-card-header">
             <h2 id="modalTitle">
-                {% if request.user.is_authenticated %}
-                    Daily Status Report
-                {% endif %}
+                {% if request.user.is_authenticated %}Daily Status Report{% endif %}
             </h2>
             <span class="close-button" aria-label="Close">x</span>
         </div>
-               
         <!-- Check-In Form -->
         <form id="checkInForm"
               class="modal-form"

--- a/website/templates/includes/checkInModal.html
+++ b/website/templates/includes/checkInModal.html
@@ -6,29 +6,11 @@
             <h2 id="modalTitle">
                 {% if request.user.is_authenticated %}
                     Daily Status Report
-                {% else %}
-                    Login
                 {% endif %}
             </h2>
             <span class="close-button" aria-label="Close">x</span>
         </div>
-        <!-- Login Form -->
-        <form id="loginForm"
-              class="modal-form"
-              method="post"
-              action="/accounts/login/"
-              {% if request.user.is_authenticated %}style="display:none;"{% endif %}>
-            {% csrf_token %}
-            <div class="form-group">
-                <label for="login_username">Username</label>
-                <input type="text" id="login_username" name="login" required>
-            </div>
-            <div class="form-group">
-                <label for="login_password">Password</label>
-                <input type="password" id="login_password" name="password" required>
-            </div>
-            <button type="submit" class="submit-button">Login</button>
-        </form>
+               
         <!-- Check-In Form -->
         <form id="checkInForm"
               class="modal-form"


### PR DESCRIPTION
closes #3093 
What Changed:
- Login Modal Removed: The login modal has been completely removed from the Daily Status Report modal to ensure it doesn’t appear when the user is not logged in.
- Stopped Auto-Popping Daily Status Report Modal: The Daily Status Report modal now only appears when the user clicks the "Add Check-In" button, rather than automatically showing up after login or on page load.

Why This Was Done:
 - The goal is to gradually transition the Daily Status Report modal into a full-page component. Currently, the modal is still required to work as part of Issue #3092, where we are working on replacing the modal with a page.
 - As a result, we didn’t completely remove the Daily Status Report modal yet, since its functionality is still needed until the full-page replacement is implemented.
 - For now, the login modal has been removed and the automatic opening of the Daily Status Report modal has been stopped to improve user experience.  
 
Current Status:
 - Daily Status Report Modal: The modal is still in place and functional, but it will no longer pop up automatically. The user must click the "Add Check-In" button to trigger the modal.
 - Next Steps: Once the page replacement for the Daily Status Report is completed, the modal will be completely removed.