### PR TITLE
feat: add badges for project and repository view counts with copy functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <p align="center"><a href="https://github.com/OWASP/BLT/actions" rel="noopener noreferrer" target="__blank"><img alt="Build" src="https://github.com/OWASP/BLT/actions/workflows/auto-merge.yml/badge.svg"></a> <a href="https://github.com/OWASP/BLT/blob/main/LICENSE.md" rel="noopener noreferrer"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue"></a>
 <a href="https://github.com/OWASP/BLT" rel="noopener noreferrer" target="__blank"><img alt="GitHub stars" src="https://img.shields.io/github/stars/OWASP/BLT?style=social"></a></p>
 
-<img alt="Views" src="https://blt.owasp.org/projects/blt/badge"></a>
+<img alt="Views" src="https://blt.owasp.org/repos/blt/badge/">
 
 Everything is on our <a href="https://blt.owasp.org">homepage</a>
 

--- a/website/templates/projects/project_detail.html
+++ b/website/templates/projects/project_detail.html
@@ -158,6 +158,27 @@
                     </div>
                 </div>
             </div>
+            <!-- Badge URL Section -->
+            <div class="p-6 bg-gray-50 border-t border-gray-200">
+                <h3 class="text-lg font-semibold text-gray-900 mb-4">Project View Count Badge</h3>
+                <div class="flex flex-col gap-4">
+                    <!-- HTML Format -->
+                    <div class="space-y-2">
+                        <div class="text-gray-700 font-medium">HTML:</div>
+                        <div class="relative">
+                            <input type="text"
+                                   readonly
+                                   value='<img alt="Views" src="{{ request.scheme }}://{{ request.get_host }}{% url 'project-badge' project.slug %}">'
+                                   class="w-full px-4 py-2 bg-white border border-gray-300 rounded-lg pr-24 font-mono text-sm focus:ring-2 focus:ring-red-500 focus:border-transparent"
+                                   id="badge-url-html">
+                            <button onclick="copyToClipboard('badge-url-html')"
+                                    class="absolute right-2 top-1/2 -translate-y-1/2 px-3 py-1 bg-red-500 hover:bg-red-600 text-white text-sm rounded-md transition-colors">
+                                Copy
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
         <!-- Associated Repositories -->
         <div class="grid gap-6">
@@ -287,3 +308,37 @@
         </div>
     </div>
 {% endblock content %}
+{% block after_js %}
+    <script>
+    function copyToClipboard(elementId) {
+        const element = document.getElementById(elementId);
+        
+        // Select the text
+        element.select();
+        element.setSelectionRange(0, 99999); // For mobile devices
+
+        // Copy the text
+        try {
+            navigator.clipboard.writeText(element.value).then(() => {
+                // Get the button
+                const button = element.nextElementSibling;
+                const originalText = button.textContent;
+                
+                // Change button style to show success
+                button.textContent = 'Copied!';
+                button.classList.remove('bg-red-500', 'hover:bg-red-600');
+                button.classList.add('bg-green-500', 'hover:bg-green-600');
+                
+                // Reset button after 2 seconds
+                setTimeout(() => {
+                    button.textContent = originalText;
+                    button.classList.remove('bg-green-500', 'hover:bg-green-600');
+                    button.classList.add('bg-red-500', 'hover:bg-red-600');
+                }, 2000);
+            });
+        } catch (err) {
+            console.error('Failed to copy text: ', err);
+        }
+    }
+    </script>
+{% endblock %}

--- a/website/templates/projects/project_detail.html
+++ b/website/templates/projects/project_detail.html
@@ -168,7 +168,7 @@
                         <div class="relative">
                             <input type="text"
                                    readonly
-                                   value='<img alt="Views" src="{{ request.scheme }}://{{ request.get_host }}{% url 'project-badge' project.slug %}">'
+                                   value='&lt;img alt="Views" src="{{ request.scheme }}://{{ request.get_host }}{% url 'project-badge' project.slug %}" &gt;'
                                    class="w-full px-4 py-2 bg-white border border-gray-300 rounded-lg pr-24 font-mono text-sm focus:ring-2 focus:ring-red-500 focus:border-transparent"
                                    id="badge-url-html">
                             <button onclick="copyToClipboard('badge-url-html')"

--- a/website/templates/projects/repo_detail.html
+++ b/website/templates/projects/repo_detail.html
@@ -72,6 +72,27 @@
                     </a>
                 </div>
             </div>
+            <!-- Badge URL Section -->
+            <div class="mt-6 p-4 bg-gray-50 rounded-lg border border-gray-200">
+                <h3 class="text-lg font-semibold text-gray-900 mb-4">Repository View Count Badge</h3>
+                <div class="flex flex-col gap-4">
+                    <!-- HTML Format -->
+                    <div class="space-y-2">
+                        <div class="text-gray-700 font-medium">HTML:</div>
+                        <div class="relative">
+                            <input type="text"
+                                   readonly
+                                   value='<img alt="Views" src="{{ request.scheme }}://{{ request.get_host }}{% url 'repo-badge' repo.slug %}">'
+                                   class="w-full px-4 py-2 bg-white border border-gray-300 rounded-lg pr-24 font-mono text-sm focus:ring-2 focus:ring-red-500 focus:border-transparent"
+                                   id="badge-url-html">
+                            <button onclick="copyToClipboard('badge-url-html')"
+                                    class="absolute right-2 top-1/2 -translate-y-1/2 px-3 py-1 bg-red-500 hover:bg-red-600 text-white text-sm rounded-md transition-colors">
+                                Copy
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
             <!-- Repository Type & Metadata -->
             <div class="mt-6 flex items-center justify-between border-t border-gray-200 pt-6">
                 <div class="flex items-center gap-6">
@@ -740,7 +761,38 @@
 {% endblock content %}
 {% block after_js %}
     <script>
-const refreshSection = async (button, section) => {
+    function copyToClipboard(elementId) {
+        const element = document.getElementById(elementId);
+        
+        // Select the text
+        element.select();
+        element.setSelectionRange(0, 99999); // For mobile devices
+
+        // Copy the text
+        try {
+            navigator.clipboard.writeText(element.value).then(() => {
+                // Get the button
+                const button = element.nextElementSibling;
+                const originalText = button.textContent;
+                
+                // Change button style to show success
+                button.textContent = 'Copied!';
+                button.classList.remove('bg-red-500', 'hover:bg-red-600');
+                button.classList.add('bg-green-500', 'hover:bg-green-600');
+                
+                // Reset button after 2 seconds
+                setTimeout(() => {
+                    button.textContent = originalText;
+                    button.classList.remove('bg-green-500', 'hover:bg-green-600');
+                    button.classList.add('bg-red-500', 'hover:bg-red-600');
+                }, 2000);
+            });
+        } catch (err) {
+            console.error('Failed to copy text: ', err);
+        }
+    }
+
+    const refreshSection = async (button, section) => {
     if (button.classList.contains('refresh_spinner')) {
         return;
     }

--- a/website/templates/projects/repo_detail.html
+++ b/website/templates/projects/repo_detail.html
@@ -82,7 +82,7 @@
                         <div class="relative">
                             <input type="text"
                                    readonly
-                                   value='<img alt="Views" src="{{ request.scheme }}://{{ request.get_host }}{% url 'repo-badge' repo.slug %}">'
+                                   value='&lt;img alt="Views" src="{{ request.scheme }}://{{ request.get_host }}{% url 'repo-badge' repo.slug %}" &gt;'
                                    class="w-full px-4 py-2 bg-white border border-gray-300 rounded-lg pr-24 font-mono text-sm focus:ring-2 focus:ring-red-500 focus:border-transparent"
                                    id="badge-url-html">
                             <button onclick="copyToClipboard('badge-url-html')"


### PR DESCRIPTION
This pull request includes several updates to the `website/templates/projects` files to add a new feature for displaying and copying view count badges, as well as a minor update to the `README.md` file. The most important changes include adding the badge URL section to both project and repository detail pages, and implementing a JavaScript function to copy badge URLs to the clipboard.

@DonnieBLT sir , can you please review this PR ?
another step for fix #2972 