### PR TITLE
enhance IP address retrieval for project and repo badge view

### DIFF
--- a/website/templates/projects/project_detail.html
+++ b/website/templates/projects/project_detail.html
@@ -341,4 +341,4 @@
         }
     }
     </script>
-{% endblock %}
+{% endblock after_js %}


### PR DESCRIPTION
**Note:** Achieving 100% accurate visit counts for GitHub repositories is not possible due to limitations imposed by GitHub's `camo` proxy service. The proxy hides the actual user IP, and repeated requests may come from the same GitHub server IP. However, this implementation is optimized to handle these challenges, offering an expected accuracy of **60-70%** in most cases.

@DonnieBLT sir,,can you please review this changes ?

another step for fix #2972 