### PR TITLE
Chapter user in bot

### DIFF
--- a/website/views/slack_handlers.py
+++ b/website/views/slack_handlers.py
@@ -162,6 +162,11 @@ def slack_events(request):
                         return handle_pagination_prev(ack=lambda: None, body=payload, client=workspace_client)
                     elif action_id == "pagination_next":
                         return handle_pagination_next(ack=lambda: None, body=payload, client=workspace_client)
+                    elif action_id == "chapters_prev" or action_id == "chapters_next":
+                        return handle_chapter_pagination(action_id, payload, workspace_client)
+                    elif action_id == "select_chapter":
+                        chapter_name = payload["actions"][0]["selected_option"]["value"]
+                        return get_chapter_details(chapter_name, get_github_headers(), workspace_client, user_id)
 
             except json.JSONDecodeError:
                 return JsonResponse({"response_type": "ephemeral", "text": "⚠️ Invalid request format."}, status=400)
@@ -590,7 +595,43 @@ def slack_commands(request):
 
         elif command == "/blt":
             search_term = request.POST.get("text", "").strip()
-            if search_term == "projects" or search_term.startswith("projects "):
+            if search_term.startswith("user "):
+                username = search_term.replace("user ", "").strip()
+                # Send immediate response
+                response = JsonResponse({
+                    "response_type": "ephemeral",
+                    "text": "I've sent you the user profile in a DM! 👤"
+                })
+
+                # Process the request in a separate thread
+                def process_profile():
+                    blocks = get_user_profile(username, workspace_client, user_id)
+                    send_dm(workspace_client, user_id, f"OWASP Profile for {username}", blocks)
+
+                thread = threading.Thread(target=process_profile)
+                thread.start()
+
+                return response
+            elif search_term == "chapters" or search_term.startswith("chapters "):
+                # Send immediate response
+                response = JsonResponse({
+                    "response_type": "ephemeral",
+                    "text": "🌍 I'll send you the chapter information in a DM shortly!"
+                })
+                
+                # Process the request in a background thread
+                def process_chapters():
+                    if search_term.startswith("chapters "):
+                        additional_search_term = search_term.replace("chapters ", "")
+                    else:
+                        additional_search_term = ""
+                    get_chapter_overview(workspace_client, user_id, additional_search_term, activity)
+                
+                thread = threading.Thread(target=process_chapters)
+                thread.start()
+                
+                return response
+            elif search_term == "projects" or search_term.startswith("projects "):
                 if search_term.startswith("projects "):
                     additional_search_term = search_term.replace("projects ", "")
                 else:
@@ -1342,4 +1383,422 @@ def get_gsoc_overview(workspace_client, user_id, search_term, activity, team_id)
         activity.success = False
         activity.error_message = str(e)
         activity.save()
-        return JsonResponse({"response_type": "ephemeral", "text": f"❌ Error: {str(e)}"}, status=400)
+        return JsonResponse({"response_type": "ephemeral", "text": f"❌ Error: Check the logs for more details."}, status=400)
+
+
+def get_user_profile(username, workspace_client, user_id):
+    """
+    Get comprehensive OWASP profile for a GitHub user.
+    Returns formatted blocks for Slack message.
+    """
+    try:
+        headers = get_github_headers()
+        if not GITHUB_TOKEN:
+            return [{
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": "⚠️ GitHub API token not configured. Please contact the administrator."}
+            }]
+
+        # Fetch basic GitHub profile
+        gh_response = requests.get(f"https://api.github.com/users/{username}", headers=headers, timeout=10)
+        
+        if gh_response.status_code == 404:
+            return [{
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": f"❌ GitHub user '{username}' not found."}
+            }]
+        elif gh_response.status_code != 200:
+            return [{
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": "❌ Failed to fetch GitHub profile."}
+            }]
+
+        profile = gh_response.json()
+        
+        # Initialize blocks with header
+        blocks = [
+            {
+                "type": "header",
+                "text": {"type": "plain_text", "text": f"🔍 OWASP Profile: {profile.get('name', username)}", "emoji": True}
+            },
+            {"type": "divider"},
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": (
+                        f"*GitHub Profile:* <{profile['html_url']}|@{username}>\n"
+                        f"*Location:* {profile.get('location', 'Not specified')}\n"
+                        f"*Bio:* {profile.get('bio', 'No bio provided')}"
+                    )
+                },
+                "accessory": {
+                    "type": "image",
+                    "image_url": profile['avatar_url'],
+                    "alt_text": f"GitHub avatar for {username}"
+                } if profile.get('avatar_url') else None
+            }
+        ]
+
+        # Fetch OWASP contributions
+        contributions = get_owasp_contributions(username, headers)
+        if contributions:
+            blocks.extend([
+                {"type": "divider"},
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": "*🛠 OWASP Contributions*"}
+                },
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": contributions}
+                }
+            ])
+
+        # Check GSoC mentorship
+        gsoc_info = get_gsoc_involvement(username)
+        if gsoc_info:
+            blocks.extend([
+                {"type": "divider"},
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": "*🎓 GSoC Involvement*"}
+                },
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": gsoc_info}
+                }
+            ])
+
+        # Add quick actions
+        blocks.extend([
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "View GitHub Profile", "emoji": True},
+                        "url": profile['html_url'],
+                        "action_id": "view_github"
+                    },
+                ]
+            }
+        ])
+
+        return blocks
+
+    except Exception as e:
+        print(f"Error in get_user_profile: {str(e)}")
+        return [{
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": "❌ An error occurred while fetching user profile."}
+        }]
+
+def get_owasp_contributions(username, headers):
+    """Get user's contributions to OWASP projects across both OWASP and OWASP-BLT organizations"""
+    try:
+        # Search for PRs in both OWASP and OWASP-BLT repositories
+        owasp_prs = get_org_prs(username, "OWASP", headers)
+        blt_prs = get_org_prs(username, "OWASP-BLT", headers)
+        
+        total_prs = (owasp_prs.get('total_count', 0) if owasp_prs else 0) + \
+                    (blt_prs.get('total_count', 0) if blt_prs else 0)
+
+        contribution_text = []
+
+        if total_prs > 0:
+            contribution_text.append(f"• Pull Requests: {total_prs} contributions to OWASP projects")
+
+        return "\n".join(contribution_text) if contribution_text else None
+
+    except Exception as e:
+        print(f"Error getting contributions: {str(e)}")
+        return None
+
+def get_org_prs(username, org, headers):
+    """Helper function to get PRs for a specific organization"""
+    try:
+        search_url = f"https://api.github.com/search/issues?q=author:{username}+org:{org}+type:pr"
+        pr_response = requests.get(search_url, headers=headers, timeout=10)
+        
+        if pr_response.status_code == 200:
+            return pr_response.json()
+        return None
+        
+    except Exception as e:
+        print(f"Error getting PRs for {org}: {str(e)}")
+        return None
+
+
+def get_gsoc_involvement(username):
+    """Check if user is a GSoC mentor"""
+    try:
+        # Check against GSOC_PROJECTS for mentorship
+        mentor_projects = [
+            project for project in GSOC_PROJECTS 
+            if username.lower() in project['mentor'].lower()
+        ]
+        
+        if mentor_projects:
+            projects_text = "\n".join(
+                f"• Mentor for *{project['title']}*" 
+                for project in mentor_projects
+            )
+            return f"🎯 GSoC Mentor:\n{projects_text}"
+            
+        return None
+
+    except Exception as e:
+        print(f"Error checking GSoC involvement: {str(e)}")
+        return None
+
+def get_chapter_overview(workspace_client, user_id, search_term, activity):
+    """Handle chapter repository overview and search"""
+    try:
+        headers = get_github_headers()
+        if not GITHUB_TOKEN:
+            send_dm(workspace_client, user_id, "Error", [{
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": "⚠️ GitHub API token not configured. Please contact the administrator."}
+            }])
+            return
+
+        # If searching for a specific chapter
+        if search_term:
+            # Format chapter name to match repository naming convention
+            chapter_name = f"www-chapter-{search_term.lower().replace(' ', '-')}"
+            get_chapter_details(chapter_name, headers, workspace_client, user_id)
+            return
+        
+        # Get all chapter repositories
+        search_url = "https://api.github.com/search/repositories"
+        params = {
+            "q": "org:OWASP www-chapter in:name",
+            "sort": "updated",
+            "order": "desc",
+            "per_page": 100
+        }
+        
+        response = requests.get(search_url, headers=headers, params=params, timeout=10)
+        
+        if response.status_code != 200:
+            send_dm(workspace_client, user_id, "Error", [{
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": "❌ Failed to fetch chapter repositories."}
+            }])
+            return
+
+        repos = response.json()['items']
+        
+        # Store pagination data
+        pagination_data[user_id] = {
+            "repos": repos,
+            "current_page": 0,
+            "page_size": 10
+        }
+
+        # Send first page
+        send_chapter_page(workspace_client, user_id, repos[:10])
+
+    except Exception as e:
+        print(f"Error in get_chapter_overview: {str(e)}")
+        activity.success = False
+        activity.error_message = str(e)
+        activity.save()
+        send_dm(workspace_client, user_id, "Error", [{
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": "❌ An error occurred while fetching chapter information."}
+        }])
+
+def send_chapter_page(client, user_id, chapters):
+    """Send a page of chapter repositories to the user"""
+    try:
+        blocks = [
+            {
+                "type": "header",
+                "text": {"type": "plain_text", "text": "🌍 OWASP Chapters", "emoji": True}
+            },
+            {"type": "divider"}
+        ]
+
+        for chapter in chapters:
+            # Extract chapter location from repo name
+            chapter_name = chapter['name'].replace('www-chapter-', '').replace('-', ' ').title()
+            
+            blocks.append({
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": (
+                        f"*{chapter_name}*\n"
+                        f"📝 {chapter.get('description', 'No description available')}\n"
+                        f"⭐ Stars: {chapter['stargazers_count']} | "
+                        f"👀 Watchers: {chapter['watchers_count']} | "
+                        f"🔄 Forks: {chapter['forks_count']}"
+                    )
+                }
+            })
+
+        # Add navigation buttons
+        navigation = {
+            "type": "actions",
+            "elements": []
+        }
+
+        data = pagination_data.get(user_id, {})
+        current_page = data.get('current_page', 0)
+        total_pages = math.ceil(len(data.get('repos', [])) / data.get('page_size', 10))
+
+        if current_page > 0:
+            navigation["elements"].append({
+                "type": "button",
+                "text": {"type": "plain_text", "text": "◀️ Previous", "emoji": True},
+                "value": "prev",
+                "action_id": "chapters_prev"
+            })
+
+        if current_page < total_pages - 1:
+            navigation["elements"].append({
+                "type": "button",
+                "text": {"type": "plain_text", "text": "Next ▶️", "emoji": True},
+                "value": "next",
+                "action_id": "chapters_next"
+            })
+
+        # Add chapter selector
+        if chapters:
+            navigation["elements"].append({
+                "type": "static_select",
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "View Chapter Details",
+                    "emoji": True
+                },
+                "options": [{
+                    "text": {
+                        "type": "plain_text",
+                        "text": chapter['name'].replace('www-chapter-', '').replace('-', ' ').title(),
+                        "emoji": True
+                    },
+                    "value": chapter['name']
+                } for chapter in chapters],
+                "action_id": "select_chapter"
+            })
+
+        blocks.append(navigation)
+        
+        send_dm(client, user_id, "OWASP Chapters", blocks)
+
+    except Exception as e:
+        print(f"Error sending chapter page: {str(e)}")
+
+def get_chapter_details(repo_name, headers, workspace_client, user_id):
+    """Get detailed information about a specific chapter repository"""
+    try:
+        # Get repository details
+        repo_url = f"https://api.github.com/repos/OWASP/{repo_name}"
+        repo_response = requests.get(repo_url, headers=headers, timeout=10)
+        
+        if repo_response.status_code == 404:
+            return JsonResponse({
+                "response_type": "ephemeral",
+                "text": f"❌ Chapter repository '{repo_name}' not found."
+            })
+        elif repo_response.status_code != 200:
+            return JsonResponse({
+                "response_type": "ephemeral",
+                "text": "❌ Failed to fetch chapter details."
+            })
+
+        repo = repo_response.json()
+        
+        # Get contributors count
+        contributors_url = f"https://api.github.com/repos/OWASP/{repo_name}/contributors"
+        contributors_response = requests.get(contributors_url, headers=headers, timeout=10)
+        contributors_count = len(contributors_response.json()) if contributors_response.status_code == 200 else 0
+
+        # Get languages
+        languages_url = f"https://api.github.com/repos/OWASP/{repo_name}/languages"
+        languages_response = requests.get(languages_url, headers=headers, timeout=10)
+        languages = list(languages_response.json().keys()) if languages_response.status_code == 200 else []
+
+        # Format chapter name
+        chapter_name = repo_name.replace('www-chapter-', '').replace('-', ' ').title()
+
+        blocks = [
+            {
+                "type": "header",
+                "text": {"type": "plain_text", "text": f"🌍 OWASP {chapter_name} Chapter", "emoji": True}
+            },
+            {"type": "divider"},
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": (
+                        f"*About:*\n{repo.get('description', 'No description available')}\n\n"
+                        f"*Stats:*\n"
+                        f"• 👥 Contributors: {contributors_count}\n"
+                        f"• ⭐ Stars: {repo['stargazers_count']}\n"
+                        f"• 👀 Watchers: {repo['watchers_count']}\n"
+                        f"• 🔄 Forks: {repo['forks_count']}\n\n"
+                        f"*Tech Stack:*\n{', '.join(languages) if languages else 'No languages detected'}"
+                    )
+                }
+            },
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "View Repository", "emoji": True},
+                        "url": repo['html_url'],
+                        "action_id": "view_chapter_repo"
+                    }
+                ]
+            }
+        ]
+
+        send_dm(workspace_client, user_id, f"OWASP {chapter_name} Chapter", blocks)
+        return JsonResponse({
+            "response_type": "ephemeral",
+            "text": f"I've sent you the details for the {chapter_name} chapter in a DM! 🌍"
+        })
+
+    except Exception as e:
+        print(f"Error getting chapter details: {str(e)}")
+        return JsonResponse({
+            "response_type": "ephemeral",
+            "text": "❌ An error occurred while fetching chapter details."
+        })
+
+def handle_chapter_pagination(action, body, client):
+    """Handle chapter pagination buttons"""
+    try:
+        user_id = body["user"]["id"]
+        data = pagination_data.get(user_id)
+        
+        if not data:
+            return JsonResponse({
+                "response_type": "ephemeral",
+                "text": "❌ No pagination data found. Please try the command again."
+            })
+
+        if action == "chapters_prev":
+            data["current_page"] = max(0, data["current_page"] - 1)
+        else:  # chapters_next
+            data["current_page"] += 1
+
+        start_idx = data["current_page"] * data["page_size"]
+        end_idx = start_idx + data["page_size"]
+        current_chapters = data["repos"][start_idx:end_idx]
+
+        send_chapter_page(client, user_id, current_chapters)
+        return HttpResponse()
+
+    except Exception as e:
+        print(f"Error handling chapter pagination: {str(e)}")
+        return JsonResponse({
+            "response_type": "ephemeral",
+            "text": "❌ An error occurred while navigating chapters."
+        })

--- a/website/views/slack_handlers.py
+++ b/website/views/slack_handlers.py
@@ -598,10 +598,9 @@ def slack_commands(request):
             if search_term.startswith("user "):
                 username = search_term.replace("user ", "").strip()
                 # Send immediate response
-                response = JsonResponse({
-                    "response_type": "ephemeral",
-                    "text": "I've sent you the user profile in a DM! 👤"
-                })
+                response = JsonResponse(
+                    {"response_type": "ephemeral", "text": "I've sent you the user profile in a DM! 👤"}
+                )
 
                 # Process the request in a separate thread
                 def process_profile():
@@ -614,11 +613,10 @@ def slack_commands(request):
                 return response
             elif search_term == "chapters" or search_term.startswith("chapters "):
                 # Send immediate response
-                response = JsonResponse({
-                    "response_type": "ephemeral",
-                    "text": "🌍 I'll send you the chapter information in a DM shortly!"
-                })
-                
+                response = JsonResponse(
+                    {"response_type": "ephemeral", "text": "🌍 I'll send you the chapter information in a DM shortly!"}
+                )
+
                 # Process the request in a background thread
                 def process_chapters():
                     if search_term.startswith("chapters "):
@@ -626,10 +624,10 @@ def slack_commands(request):
                     else:
                         additional_search_term = ""
                     get_chapter_overview(workspace_client, user_id, additional_search_term, activity)
-                
+
                 thread = threading.Thread(target=process_chapters)
                 thread.start()
-                
+
                 return response
             elif search_term == "projects" or search_term.startswith("projects "):
                 if search_term.startswith("projects "):
@@ -1383,7 +1381,9 @@ def get_gsoc_overview(workspace_client, user_id, search_term, activity, team_id)
         activity.success = False
         activity.error_message = str(e)
         activity.save()
-        return JsonResponse({"response_type": "ephemeral", "text": f"❌ Error: Check the logs for more details."}, status=400)
+        return JsonResponse(
+            {"response_type": "ephemeral", "text": "❌ Error: Check the logs for more details."}, status=400
+        )
 
 
 def get_user_profile(username, workspace_client, user_id):
@@ -1394,32 +1394,35 @@ def get_user_profile(username, workspace_client, user_id):
     try:
         headers = get_github_headers()
         if not GITHUB_TOKEN:
-            return [{
-                "type": "section",
-                "text": {"type": "mrkdwn", "text": "⚠️ GitHub API token not configured. Please contact the administrator."}
-            }]
+            return [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "⚠️ GitHub API token not configured. Please contact the administrator.",
+                    },
+                }
+            ]
 
         # Fetch basic GitHub profile
         gh_response = requests.get(f"https://api.github.com/users/{username}", headers=headers, timeout=10)
-        
+
         if gh_response.status_code == 404:
-            return [{
-                "type": "section",
-                "text": {"type": "mrkdwn", "text": f"❌ GitHub user '{username}' not found."}
-            }]
+            return [{"type": "section", "text": {"type": "mrkdwn", "text": f"❌ GitHub user '{username}' not found."}}]
         elif gh_response.status_code != 200:
-            return [{
-                "type": "section",
-                "text": {"type": "mrkdwn", "text": "❌ Failed to fetch GitHub profile."}
-            }]
+            return [{"type": "section", "text": {"type": "mrkdwn", "text": "❌ Failed to fetch GitHub profile."}}]
 
         profile = gh_response.json()
-        
+
         # Initialize blocks with header
         blocks = [
             {
                 "type": "header",
-                "text": {"type": "plain_text", "text": f"🔍 OWASP Profile: {profile.get('name', username)}", "emoji": True}
+                "text": {
+                    "type": "plain_text",
+                    "text": f"🔍 OWASP Profile: {profile.get('name', username)}",
+                    "emoji": True,
+                },
             },
             {"type": "divider"},
             {
@@ -1430,69 +1433,65 @@ def get_user_profile(username, workspace_client, user_id):
                         f"*GitHub Profile:* <{profile['html_url']}|@{username}>\n"
                         f"*Location:* {profile.get('location', 'Not specified')}\n"
                         f"*Bio:* {profile.get('bio', 'No bio provided')}"
-                    )
+                    ),
                 },
                 "accessory": {
                     "type": "image",
-                    "image_url": profile['avatar_url'],
-                    "alt_text": f"GitHub avatar for {username}"
-                } if profile.get('avatar_url') else None
-            }
+                    "image_url": profile["avatar_url"],
+                    "alt_text": f"GitHub avatar for {username}",
+                }
+                if profile.get("avatar_url")
+                else None,
+            },
         ]
 
         # Fetch OWASP contributions
         contributions = get_owasp_contributions(username, headers)
         if contributions:
-            blocks.extend([
-                {"type": "divider"},
-                {
-                    "type": "section",
-                    "text": {"type": "mrkdwn", "text": "*🛠 OWASP Contributions*"}
-                },
-                {
-                    "type": "section",
-                    "text": {"type": "mrkdwn", "text": contributions}
-                }
-            ])
+            blocks.extend(
+                [
+                    {"type": "divider"},
+                    {"type": "section", "text": {"type": "mrkdwn", "text": "*🛠 OWASP Contributions*"}},
+                    {"type": "section", "text": {"type": "mrkdwn", "text": contributions}},
+                ]
+            )
 
         # Check GSoC mentorship
         gsoc_info = get_gsoc_involvement(username)
         if gsoc_info:
-            blocks.extend([
-                {"type": "divider"},
-                {
-                    "type": "section",
-                    "text": {"type": "mrkdwn", "text": "*🎓 GSoC Involvement*"}
-                },
-                {
-                    "type": "section",
-                    "text": {"type": "mrkdwn", "text": gsoc_info}
-                }
-            ])
+            blocks.extend(
+                [
+                    {"type": "divider"},
+                    {"type": "section", "text": {"type": "mrkdwn", "text": "*🎓 GSoC Involvement*"}},
+                    {"type": "section", "text": {"type": "mrkdwn", "text": gsoc_info}},
+                ]
+            )
 
         # Add quick actions
-        blocks.extend([
-            {
-                "type": "actions",
-                "elements": [
-                    {
-                        "type": "button",
-                        "text": {"type": "plain_text", "text": "View GitHub Profile", "emoji": True},
-                        "url": profile['html_url'],
-                        "action_id": "view_github"
-                    },
-                ]
-            }
-        ])
+        blocks.extend(
+            [
+                {
+                    "type": "actions",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "text": {"type": "plain_text", "text": "View GitHub Profile", "emoji": True},
+                            "url": profile["html_url"],
+                            "action_id": "view_github",
+                        },
+                    ],
+                }
+            ]
+        )
 
         return blocks
 
     except Exception as e:
         print(f"Error in get_user_profile: {str(e)}")
-        return [{
-            "type": "section",
-            "text": {"type": "mrkdwn", "text": "❌ An error occurred while fetching user profile."}
-        }]
+        return [
+            {"type": "section", "text": {"type": "mrkdwn", "text": "❌ An error occurred while fetching user profile."}}
+        ]
+
 
 def get_owasp_contributions(username, headers):
     """Get user's contributions to OWASP projects across both OWASP and OWASP-BLT organizations"""
@@ -1500,9 +1499,10 @@ def get_owasp_contributions(username, headers):
         # Search for PRs in both OWASP and OWASP-BLT repositories
         owasp_prs = get_org_prs(username, "OWASP", headers)
         blt_prs = get_org_prs(username, "OWASP-BLT", headers)
-        
-        total_prs = (owasp_prs.get('total_count', 0) if owasp_prs else 0) + \
-                    (blt_prs.get('total_count', 0) if blt_prs else 0)
+
+        total_prs = (owasp_prs.get("total_count", 0) if owasp_prs else 0) + (
+            blt_prs.get("total_count", 0) if blt_prs else 0
+        )
 
         contribution_text = []
 
@@ -1515,16 +1515,17 @@ def get_owasp_contributions(username, headers):
         print(f"Error getting contributions: {str(e)}")
         return None
 
+
 def get_org_prs(username, org, headers):
     """Helper function to get PRs for a specific organization"""
     try:
         search_url = f"https://api.github.com/search/issues?q=author:{username}+org:{org}+type:pr"
         pr_response = requests.get(search_url, headers=headers, timeout=10)
-        
+
         if pr_response.status_code == 200:
             return pr_response.json()
         return None
-        
+
     except Exception as e:
         print(f"Error getting PRs for {org}: {str(e)}")
         return None
@@ -1534,33 +1535,38 @@ def get_gsoc_involvement(username):
     """Check if user is a GSoC mentor"""
     try:
         # Check against GSOC_PROJECTS for mentorship
-        mentor_projects = [
-            project for project in GSOC_PROJECTS 
-            if username.lower() in project['mentor'].lower()
-        ]
-        
+        mentor_projects = [project for project in GSOC_PROJECTS if username.lower() in project["mentor"].lower()]
+
         if mentor_projects:
-            projects_text = "\n".join(
-                f"• Mentor for *{project['title']}*" 
-                for project in mentor_projects
-            )
+            projects_text = "\n".join(f"• Mentor for *{project['title']}*" for project in mentor_projects)
             return f"🎯 GSoC Mentor:\n{projects_text}"
-            
+
         return None
 
     except Exception as e:
         print(f"Error checking GSoC involvement: {str(e)}")
         return None
 
+
 def get_chapter_overview(workspace_client, user_id, search_term, activity):
     """Handle chapter repository overview and search"""
     try:
         headers = get_github_headers()
         if not GITHUB_TOKEN:
-            send_dm(workspace_client, user_id, "Error", [{
-                "type": "section",
-                "text": {"type": "mrkdwn", "text": "⚠️ GitHub API token not configured. Please contact the administrator."}
-            }])
+            send_dm(
+                workspace_client,
+                user_id,
+                "Error",
+                [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "⚠️ GitHub API token not configured. Please contact the administrator.",
+                        },
+                    }
+                ],
+            )
             return
 
         # If searching for a specific chapter
@@ -1569,33 +1575,26 @@ def get_chapter_overview(workspace_client, user_id, search_term, activity):
             chapter_name = f"www-chapter-{search_term.lower().replace(' ', '-')}"
             get_chapter_details(chapter_name, headers, workspace_client, user_id)
             return
-        
+
         # Get all chapter repositories
         search_url = "https://api.github.com/search/repositories"
-        params = {
-            "q": "org:OWASP www-chapter in:name",
-            "sort": "updated",
-            "order": "desc",
-            "per_page": 100
-        }
-        
+        params = {"q": "org:OWASP www-chapter in:name", "sort": "updated", "order": "desc", "per_page": 100}
+
         response = requests.get(search_url, headers=headers, params=params, timeout=10)
-        
+
         if response.status_code != 200:
-            send_dm(workspace_client, user_id, "Error", [{
-                "type": "section",
-                "text": {"type": "mrkdwn", "text": "❌ Failed to fetch chapter repositories."}
-            }])
+            send_dm(
+                workspace_client,
+                user_id,
+                "Error",
+                [{"type": "section", "text": {"type": "mrkdwn", "text": "❌ Failed to fetch chapter repositories."}}],
+            )
             return
 
-        repos = response.json()['items']
-        
+        repos = response.json()["items"]
+
         # Store pagination data
-        pagination_data[user_id] = {
-            "repos": repos,
-            "current_page": 0,
-            "page_size": 10
-        }
+        pagination_data[user_id] = {"repos": repos, "current_page": 0, "page_size": 10}
 
         # Send first page
         send_chapter_page(workspace_client, user_id, repos[:10])
@@ -1605,92 +1604,102 @@ def get_chapter_overview(workspace_client, user_id, search_term, activity):
         activity.success = False
         activity.error_message = str(e)
         activity.save()
-        send_dm(workspace_client, user_id, "Error", [{
-            "type": "section",
-            "text": {"type": "mrkdwn", "text": "❌ An error occurred while fetching chapter information."}
-        }])
+        send_dm(
+            workspace_client,
+            user_id,
+            "Error",
+            [
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": "❌ An error occurred while fetching chapter information."},
+                }
+            ],
+        )
+
 
 def send_chapter_page(client, user_id, chapters):
     """Send a page of chapter repositories to the user"""
     try:
         blocks = [
-            {
-                "type": "header",
-                "text": {"type": "plain_text", "text": "🌍 OWASP Chapters", "emoji": True}
-            },
-            {"type": "divider"}
+            {"type": "header", "text": {"type": "plain_text", "text": "🌍 OWASP Chapters", "emoji": True}},
+            {"type": "divider"},
         ]
 
         for chapter in chapters:
             # Extract chapter location from repo name
-            chapter_name = chapter['name'].replace('www-chapter-', '').replace('-', ' ').title()
-            
-            blocks.append({
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": (
-                        f"*{chapter_name}*\n"
-                        f"📝 {chapter.get('description', 'No description available')}\n"
-                        f"⭐ Stars: {chapter['stargazers_count']} | "
-                        f"👀 Watchers: {chapter['watchers_count']} | "
-                        f"🔄 Forks: {chapter['forks_count']}"
-                    )
+            chapter_name = chapter["name"].replace("www-chapter-", "").replace("-", " ").title()
+
+            blocks.append(
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": (
+                            f"*{chapter_name}*\n"
+                            f"📝 {chapter.get('description', 'No description available')}\n"
+                            f"⭐ Stars: {chapter['stargazers_count']} | "
+                            f"👀 Watchers: {chapter['watchers_count']} | "
+                            f"🔄 Forks: {chapter['forks_count']}"
+                        ),
+                    },
                 }
-            })
+            )
 
         # Add navigation buttons
-        navigation = {
-            "type": "actions",
-            "elements": []
-        }
+        navigation = {"type": "actions", "elements": []}
 
         data = pagination_data.get(user_id, {})
-        current_page = data.get('current_page', 0)
-        total_pages = math.ceil(len(data.get('repos', [])) / data.get('page_size', 10))
+        current_page = data.get("current_page", 0)
+        total_pages = math.ceil(len(data.get("repos", [])) / data.get("page_size", 10))
 
         if current_page > 0:
-            navigation["elements"].append({
-                "type": "button",
-                "text": {"type": "plain_text", "text": "◀️ Previous", "emoji": True},
-                "value": "prev",
-                "action_id": "chapters_prev"
-            })
+            navigation["elements"].append(
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "◀️ Previous", "emoji": True},
+                    "value": "prev",
+                    "action_id": "chapters_prev",
+                }
+            )
 
         if current_page < total_pages - 1:
-            navigation["elements"].append({
-                "type": "button",
-                "text": {"type": "plain_text", "text": "Next ▶️", "emoji": True},
-                "value": "next",
-                "action_id": "chapters_next"
-            })
+            navigation["elements"].append(
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Next ▶️", "emoji": True},
+                    "value": "next",
+                    "action_id": "chapters_next",
+                }
+            )
 
         # Add chapter selector
         if chapters:
-            navigation["elements"].append({
-                "type": "static_select",
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "View Chapter Details",
-                    "emoji": True
-                },
-                "options": [{
-                    "text": {
-                        "type": "plain_text",
-                        "text": chapter['name'].replace('www-chapter-', '').replace('-', ' ').title(),
-                        "emoji": True
-                    },
-                    "value": chapter['name']
-                } for chapter in chapters],
-                "action_id": "select_chapter"
-            })
+            navigation["elements"].append(
+                {
+                    "type": "static_select",
+                    "placeholder": {"type": "plain_text", "text": "View Chapter Details", "emoji": True},
+                    "options": [
+                        {
+                            "text": {
+                                "type": "plain_text",
+                                "text": chapter["name"].replace("www-chapter-", "").replace("-", " ").title(),
+                                "emoji": True,
+                            },
+                            "value": chapter["name"],
+                        }
+                        for chapter in chapters
+                    ],
+                    "action_id": "select_chapter",
+                }
+            )
 
         blocks.append(navigation)
-        
+
         send_dm(client, user_id, "OWASP Chapters", blocks)
 
     except Exception as e:
         print(f"Error sending chapter page: {str(e)}")
+
 
 def get_chapter_details(repo_name, headers, workspace_client, user_id):
     """Get detailed information about a specific chapter repository"""
@@ -1698,20 +1707,16 @@ def get_chapter_details(repo_name, headers, workspace_client, user_id):
         # Get repository details
         repo_url = f"https://api.github.com/repos/OWASP/{repo_name}"
         repo_response = requests.get(repo_url, headers=headers, timeout=10)
-        
+
         if repo_response.status_code == 404:
-            return JsonResponse({
-                "response_type": "ephemeral",
-                "text": f"❌ Chapter repository '{repo_name}' not found."
-            })
+            return JsonResponse(
+                {"response_type": "ephemeral", "text": f"❌ Chapter repository '{repo_name}' not found."}
+            )
         elif repo_response.status_code != 200:
-            return JsonResponse({
-                "response_type": "ephemeral",
-                "text": "❌ Failed to fetch chapter details."
-            })
+            return JsonResponse({"response_type": "ephemeral", "text": "❌ Failed to fetch chapter details."})
 
         repo = repo_response.json()
-        
+
         # Get contributors count
         contributors_url = f"https://api.github.com/repos/OWASP/{repo_name}/contributors"
         contributors_response = requests.get(contributors_url, headers=headers, timeout=10)
@@ -1723,12 +1728,12 @@ def get_chapter_details(repo_name, headers, workspace_client, user_id):
         languages = list(languages_response.json().keys()) if languages_response.status_code == 200 else []
 
         # Format chapter name
-        chapter_name = repo_name.replace('www-chapter-', '').replace('-', ' ').title()
+        chapter_name = repo_name.replace("www-chapter-", "").replace("-", " ").title()
 
         blocks = [
             {
                 "type": "header",
-                "text": {"type": "plain_text", "text": f"🌍 OWASP {chapter_name} Chapter", "emoji": True}
+                "text": {"type": "plain_text", "text": f"🌍 OWASP {chapter_name} Chapter", "emoji": True},
             },
             {"type": "divider"},
             {
@@ -1743,8 +1748,8 @@ def get_chapter_details(repo_name, headers, workspace_client, user_id):
                         f"• 👀 Watchers: {repo['watchers_count']}\n"
                         f"• 🔄 Forks: {repo['forks_count']}\n\n"
                         f"*Tech Stack:*\n{', '.join(languages) if languages else 'No languages detected'}"
-                    )
-                }
+                    ),
+                },
             },
             {
                 "type": "actions",
@@ -1752,37 +1757,38 @@ def get_chapter_details(repo_name, headers, workspace_client, user_id):
                     {
                         "type": "button",
                         "text": {"type": "plain_text", "text": "View Repository", "emoji": True},
-                        "url": repo['html_url'],
-                        "action_id": "view_chapter_repo"
+                        "url": repo["html_url"],
+                        "action_id": "view_chapter_repo",
                     }
-                ]
-            }
+                ],
+            },
         ]
 
         send_dm(workspace_client, user_id, f"OWASP {chapter_name} Chapter", blocks)
-        return JsonResponse({
-            "response_type": "ephemeral",
-            "text": f"I've sent you the details for the {chapter_name} chapter in a DM! 🌍"
-        })
+        return JsonResponse(
+            {
+                "response_type": "ephemeral",
+                "text": f"I've sent you the details for the {chapter_name} chapter in a DM! 🌍",
+            }
+        )
 
     except Exception as e:
         print(f"Error getting chapter details: {str(e)}")
-        return JsonResponse({
-            "response_type": "ephemeral",
-            "text": "❌ An error occurred while fetching chapter details."
-        })
+        return JsonResponse(
+            {"response_type": "ephemeral", "text": "❌ An error occurred while fetching chapter details."}
+        )
+
 
 def handle_chapter_pagination(action, body, client):
     """Handle chapter pagination buttons"""
     try:
         user_id = body["user"]["id"]
         data = pagination_data.get(user_id)
-        
+
         if not data:
-            return JsonResponse({
-                "response_type": "ephemeral",
-                "text": "❌ No pagination data found. Please try the command again."
-            })
+            return JsonResponse(
+                {"response_type": "ephemeral", "text": "❌ No pagination data found. Please try the command again."}
+            )
 
         if action == "chapters_prev":
             data["current_page"] = max(0, data["current_page"] - 1)
@@ -1798,7 +1804,4 @@ def handle_chapter_pagination(action, body, client):
 
     except Exception as e:
         print(f"Error handling chapter pagination: {str(e)}")
-        return JsonResponse({
-            "response_type": "ephemeral",
-            "text": "❌ An error occurred while navigating chapters."
-        })
+        return JsonResponse({"response_type": "ephemeral", "text": "❌ An error occurred while navigating chapters."})


### PR DESCRIPTION
This commit introduces comprehensive user profile and chapter exploration features for the Slack bot:
- Implemented `/blt user` command to fetch GitHub user profiles
- Added `/blt chapters` command to list and explore OWASP chapters
- Created pagination support for chapter repositories
- Added GitHub contribution and GSoC mentorship tracking
- Implemented detailed user and chapter information retrieval
- Enhanced error handling and user experience for Slack interactions


@DonnieBLT sir, can you please review this PR?

This is used to pass the test: fix #2972 