### PR TITLE
Fixes: #3226 (the github badge is not looking right)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,28 @@
 <h1 align="center"> OWASP BLT </h1>
 
-
-<p align="center"><a href="https://github.com/OWASP/BLT/actions" rel="noopener noreferrer" target="__blank"><img alt="Build" src="https://github.com/OWASP/BLT/actions/workflows/auto-merge.yml/badge.svg"></a> <a href="https://github.com/OWASP/BLT/blob/main/LICENSE.md" rel="noopener noreferrer"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue"></a>
-<a href="https://github.com/OWASP/BLT" rel="noopener noreferrer" target="__blank"><img alt="GitHub stars" src="https://img.shields.io/github/stars/OWASP/BLT?style=social"></a></p>
-
-<img alt="Views" src="https://blt.owasp.org/repos/blt/badge/">
+<p align="center">
+<a href="https://github.com/OWASP/BLT/actions" rel="noopener noreferrer" target="__blank">
+    <img alt="Build" src="https://github.com/OWASP/BLT/actions/workflows/auto-merge.yml/badge.svg">
+</a> 
+<a href="https://github.com/OWASP/BLT/blob/main/LICENSE.md" rel="noopener noreferrer">
+    <img src="https://img.shields.io/badge/license-AGPL--3.0-blue">
+</a>
+<a href="https://github.com/OWASP/BLT" rel="noopener noreferrer" target="__blank">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/OWASP/BLT?style=social">
+</a>
+<a href="https://github.com/OWASP/BLT">
+    <img alt="Views" src="https://komarev.com/ghpvc/?username=OWASP-BLT&color=blue">
+</a>
+</p>
 
 Everything is on our <a href="https://blt.owasp.org">homepage</a>
 
 ## Star History
 
-<a href="https://star-history.com/#OWASP-BLT/BLT&Date">
+<a href="https://star-history.com/#OWASP/BLT&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=OWASP-BLT/BLT&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=OWASP-BLT/BLT&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=OWASP-BLT/BLT&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=OWASP/BLT&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=OWASP/BLT&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=OWASP/BLT&type=Date" />
  </picture>
 </a>
-


### PR DESCRIPTION
Summary
This pull request resolves an issue where the GitHub badge in the README file was not displaying correctly.

Details

Updated the badge URL to ensure it reflects the repository's actual status.
Verified that the badge is now correctly rendered.
Testing

Verified the fix on local and GitHub previews. The badge now displays as expected.
Related Issues
Fixes #3226.