### PR TITLE
Fix broken GitHub Issues endpoint in BLT

### DIFF
--- a/blt/urls.py
+++ b/blt/urls.py
@@ -104,6 +104,7 @@ from website.views.core import (
 from website.views.issue import (
     AllIssuesView,
     ContributeView,
+    GitHubIssueDetailView,
     GitHubIssuesView,
     GithubIssueView,
     IssueCreate,
@@ -911,6 +912,7 @@ urlpatterns = [
     path("add_repo", add_repo, name="add_repo"),
     path("organization/<slug:slug>/", OrganizationDetailView.as_view(), name="organization_detail"),
     # GitHub Issues
+    path("github-issues/<int:pk>/", GitHubIssueDetailView.as_view(), name="github_issue_detail"),
     path("github-issues/", GitHubIssuesView.as_view(), name="github_issues"),
 ]
 


### PR DESCRIPTION
Fixes #3660

- Fixed incorrect routing for the `github-issues/` endpoint.
- Updated API paths to ensure proper request handling.