### PR TITLE
CHORE (cleanup): Remove style text (h-[100px]) from base.html

### DIFF
--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -81,7 +81,6 @@
                     crossorigin="anonymous"></script>
         {% endif %}
         {% block head %}
-            h-[100px]
         {% endblock head %}
         {% block style %}
         {% endblock style %}


### PR DESCRIPTION
The h-[100px] text was mistakenly being rendered directly on the webpage instead of being applied as a class. This change removes the unintended text from base.html, ensuring a cleaner and more accurate rendering of the page.

ISSUE #3775
