### PR TITLE
listed top contributors for gsoc2025 using GithubIssue model

### DIFF
--- a/blt/urls.py
+++ b/blt/urls.py
@@ -144,6 +144,7 @@ from website.views.issue import (
     GitHubIssueDetailView,
     GitHubIssuesView,
     GithubIssueView,
+    GsocView,
     IssueCreate,
     IssueEdit,
     IssueView,
@@ -678,7 +679,7 @@ urlpatterns = [
         update_lectures_order,
         name="update_lectures_order",
     ),
-    re_path(r"^gsoc/$", TemplateView.as_view(template_name="gsoc.html"), name="gsoc"),
+    path("gsoc/", GsocView.as_view(), name="gsoc"),
     re_path(
         r"^privacypolicy/$",
         TemplateView.as_view(template_name="privacy.html"),

--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -207,6 +207,40 @@
                     </a>
                 </div>
             </div>
+            <!-- Top Contributors Leaderboard -->
+            <div class="bg-white rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 p-8 mb-12 border-l-4 border-red-500">
+                <h2 class="text-3xl font-bold text-gray-900 mb-6">Top Contributors for GSoC 2025 Projects</h2>
+                <p class="text-gray-700 mb-4">
+                    For transparency, we are implementing a Top contributors List  for students this year. This demonstrates our commitment to working students who are contunually contributing while also signaling our intent to other projects and organizations.
+                </p>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+                    {% for project, data in projects.items %}
+                        <div class="bg-gray-50 rounded-lg p-6">
+                            <a href="{{ data.repo_url }}"
+                               target="_blank"
+                               class="text-xl font-semibold text-gray-900 mb-4">
+                                {{ project }} - Total PRs:
+                                <span class="text-red-600 font-bold">{{ data.total_prs }}</span>
+                            </a>
+                            <div class="space-y-3">
+                                {% for contributor in data.contributors %}
+                                    <div class="flex items-center justify-between p-2 hover:bg-gray-100 rounded">
+                                        <a href="{{ contributor.url }}"
+                                           target="_blank"
+                                           class="text-gray-700 hover:text-red-600">{{ contributor.username }}</a>
+                                        <span class="bg-red-100 text-red-800 text-sm font-medium px-2.5 py-0.5 rounded">
+                                            {{ contributor.prs }} PR
+                                            {% if contributor.prs != 1 %}s{% endif %}
+                                        </span>
+                                    </div>
+                                {% empty %}
+                                    <p class="text-gray-500 italic">No contributors in this period</p>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
             <!-- Past Events -->
             <div class="bg-white rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 p-8 mb-12 border-l-4 border-red-500">
                 <h2 class="text-3xl font-bold text-gray-900 mb-6">Past GSOC Events</h2>

--- a/website/views/constants.py
+++ b/website/views/constants.py
@@ -568,3 +568,19 @@ TAG_NORMALIZATION = {
     "gradle": "gradle",
     "ant": "ant",
 }
+
+GSOC25_PROJECTS = {
+    "Bug Logging Tool(BLT)": [
+        "OWASP-BLT/BLT",
+        "OWASP-BLT/BLT-Flutter",
+        "OWASP-BLT/BLT-Bacon",
+        "OWASP-BLT/BLT-Action",
+        "OWASP-BLT/BLT-Extension",
+    ],
+    "NEST": ["OWASP/Nest"],
+    "NETTACKER": ["OWASP/Nettacker"],
+    "JUICE-SHOP": ["juice-shop/juice-shop"],
+    "DevSecOps Maturity Model(DSMM)": ["devsecopsmaturitymodel/DevSecOps-MaturityModel"],
+    "PYGOAT": ["adeyosemanputra/PyGoat"],
+    "OpenCRE": ["OWASP/OpenCRE"],
+}

--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -5,6 +5,7 @@ import os
 import smtplib
 import socket
 import uuid
+from collections import defaultdict
 from datetime import datetime, timezone
 from urllib.parse import urlparse
 
@@ -41,6 +42,7 @@ from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
 from django.utils.html import escape
 from django.utils.timezone import now
+from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, ListView, TemplateView
@@ -78,6 +80,8 @@ from website.utils import (
     rebuild_safe_url,
     safe_redirect_request,
 )
+
+from .constants import GSOC25_PROJECTS
 
 
 @login_required(login_url="/accounts/login")
@@ -2008,3 +2012,71 @@ def page_vote(request):
             return JsonResponse({"status": "error", "message": "An error occurred while processing your vote"})
 
     return JsonResponse({"status": "error", "message": "Invalid request method"})
+
+
+class GsocView(View):
+    SINCE_DATE = datetime(2024, 11, 1, tzinfo=timezone.utc)
+
+    def fetch_model_prs(self, repo_names):
+        contributors = defaultdict(lambda: {"count": 0, "github_url": ""})
+        total_pr_count = 0
+
+        # Filter repos by name
+        repos = Repo.objects.filter(name__in=[name.split("/")[-1] for name in repo_names])
+
+        # Fetch merged PRs
+        prs = GitHubIssue.objects.filter(
+            repo__in=repos, type="pull_request", is_merged=True, merged_at__gte=self.SINCE_DATE
+        ).select_related("user_profile__user")
+
+        for pr in prs:
+            total_pr_count += 1
+
+            user_profile = pr.user_profile
+            if user_profile:
+                github_url = user_profile.github_url
+                if github_url and not github_url.endswith("[bot]") and "bot" not in github_url.lower():
+                    contributors[github_url]["count"] += 1
+                    contributors[github_url]["github_url"] = github_url
+
+        # Get top 10 contributors
+        top_contributors = sorted(contributors.items(), key=lambda item: item[1]["count"], reverse=True)[:10]
+
+        # Format top contributors list
+        formatted_contributors = [
+            {"url": url, "username": url.rstrip("/").split("/")[-1], "prs": data["count"]}
+            for url, data in top_contributors
+        ]
+
+        return formatted_contributors, total_pr_count
+
+    def get_repo_url(self, repo_names):
+        if not repo_names:
+            return ""
+
+        repo_name = repo_names[0].split("/")[-1]
+        try:
+            repo = Repo.objects.filter(name=repo_name).first()
+            return repo.repo_url if repo else f"https://github.com/{repo_names[0]}"
+        except:
+            return f"https://github.com/{repo_names[0]}"
+
+    def build_project_data(self, project, repo_names):
+        contributors, total_prs = self.fetch_model_prs(repo_names)
+
+        return {
+            "contributors": contributors,
+            "total_prs": total_prs,
+            "repo_url": self.get_repo_url(repo_names),
+        }
+
+    def get(self, request):
+        project_data = {}
+
+        for project, repo_names in GSOC25_PROJECTS.items():
+            project_data[project] = self.build_project_data(project, repo_names)
+
+        # Sort projects by total PRs
+        sorted_project_data = dict(sorted(project_data.items(), key=lambda item: item[1]["total_prs"], reverse=True))
+
+        return render(request, "gsoc.html", {"projects": sorted_project_data})


### PR DESCRIPTION
### **User description**
close #3672 
close #3700
 screenshot 
![image](https://github.com/user-attachments/assets/aee71f0d-0722-41cd-b9b3-d4733dc54c39)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added a leaderboard for top contributors to GSoC 2025 projects.

- Replaced static `gsoc.html` view with a dynamic Django view.

- Introduced `GSOC25_PROJECTS` constant for project-repo mapping.

- Implemented logic to fetch and display contributor data using `GitHubIssue` model.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gsoc.html</strong><dd><code>Added leaderboard section for GSoC 2025 contributors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website/templates/gsoc.html

<li>Added a leaderboard section for top contributors.<br> <li> Dynamically displays project and contributor data.<br> <li> Includes fallback for no contributors.


</details>


  </td>
  <td><a href="https://github.com/OWASP-BLT/BLT/pull/3884/files#diff-fdf8fdee1b9ebf7f11a950d30ca62dd64c46ced4947e594085ae105716824178">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>urls.py</strong><dd><code>Updated GSoC URL routing to use dynamic view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

blt/urls.py

<li>Replaced static <code>gsoc.html</code> view with <code>GsocView</code>.<br> <li> Updated URL routing for GSoC page.


</details>


  </td>
  <td><a href="https://github.com/OWASP-BLT/BLT/pull/3884/files#diff-6f5374c34e9a5f6473d578c268b01660a4611da9e85c99abdd7c2767a86af8de">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>issue.py</strong><dd><code>Added dynamic view for GSoC 2025 contributors leaderboard</code></dd></summary>
<hr>

website/views/issue.py

<li>Added <code>GsocView</code> class to dynamically fetch and display contributor <br>data.<br> <li> Implemented logic to fetch PRs and contributors using <code>GitHubIssue</code> <br>model.<br> <li> Added helper methods for repo URL and project data formatting.


</details>


  </td>
  <td><a href="https://github.com/OWASP-BLT/BLT/pull/3884/files#diff-619e9fa88e6cd3479f8df16fa64b920593af25773e83191d5e6d17640ef0a4db">+72/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>constants.py</strong><dd><code>Introduced constant for GSoC 2025 project-repo mapping</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website/views/constants.py

- Added `GSOC25_PROJECTS` constant for project-repo mapping.


</details>


  </td>
  <td><a href="https://github.com/OWASP-BLT/BLT/pull/3884/files#diff-f9704dac1eb70b0942d04e1defeac124144dda45a0ca3f6cfa498b2fb6a5a8ac">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>