### PR TITLE
fixed file handling, sanitized and restricted thumbnail uploads

### DIFF
--- a/website/test_api.py
+++ b/website/test_api.py
@@ -1,6 +1,10 @@
+from io import BytesIO
+from unittest.mock import Mock
+
 from allauth.account.models import EmailAddress
 from django.contrib.auth import get_user_model
 from django.core import mail
+from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.db.transaction import atomic
 from django.test import TestCase
 from django.urls import reverse
@@ -8,12 +12,9 @@ from django.utils import timezone
 from django.utils.encoding import force_str
 from rest_framework import status
 from rest_framework.test import APITestCase
-from django.core.files.uploadedfile import InMemoryUploadedFile
-from io import BytesIO
-from unittest.mock import Mock
-from website.utils import validate_file_type
 
-from website.utils import rebuild_safe_url
+from website.utils import rebuild_safe_url, validate_file_type
+
 
 class FileValidationTest(APITestCase):
     def test_valid_png(self):
@@ -21,19 +22,15 @@ class FileValidationTest(APITestCase):
         file_content = b"fake png content"
         file = InMemoryUploadedFile(
             file=BytesIO(file_content),
-            field_name='thumbnail',
-            name='test.png',
-            content_type='image/png',
+            field_name="thumbnail",
+            name="test.png",
+            content_type="image/png",
             size=len(file_content),
-            charset=None
+            charset=None,
         )
         request = Mock()
-        request.FILES = {'thumbnail': file}
-        is_valid, error_message = validate_file_type(
-            request,
-            'thumbnail',
-            allowed_extensions=['png']
-        )
+        request.FILES = {"thumbnail": file}
+        is_valid, error_message = validate_file_type(request, "thumbnail", allowed_extensions=["png"])
         self.assertTrue(is_valid, "Validation should pass for a valid PNG file")
         self.assertIsNone(error_message, "Error message should be None for a valid file")
 
@@ -42,19 +39,15 @@ class FileValidationTest(APITestCase):
         file_content = b"fake pdf content"
         file = InMemoryUploadedFile(
             file=BytesIO(file_content),
-            field_name='thumbnail',
-            name='test.pdf',
-            content_type='application/pdf',
+            field_name="thumbnail",
+            name="test.pdf",
+            content_type="application/pdf",
             size=len(file_content),
-            charset=None
+            charset=None,
         )
         request = Mock()
-        request.FILES = {'thumbnail': file}
-        is_valid, error_message = validate_file_type(
-            request,
-            'thumbnail',
-            allowed_extensions=['png']
-        )
+        request.FILES = {"thumbnail": file}
+        is_valid, error_message = validate_file_type(request, "thumbnail", allowed_extensions=["png"])
         self.assertFalse(is_valid, "Validation should fail for an invalid extension")
         self.assertIsNotNone(error_message, "Error message should be set for an invalid file")
 
@@ -62,13 +55,11 @@ class FileValidationTest(APITestCase):
         """Test when no file is provided."""
         request = Mock()
         request.FILES = {}
-        is_valid, error_message = validate_file_type(
-            request,
-            'thumbnail',
-            allowed_extensions=['png']
-        )
+        is_valid, error_message = validate_file_type(request, "thumbnail", allowed_extensions=["png"])
         self.assertTrue(is_valid, "Validation should pass when no file is provided")
         self.assertIsNone(error_message, "Error message should be None when no file is provided")
+
+
 class RebuildSafeUrlTestCase(TestCase):
     def test_rebuild_safe_url(self):
         print("=== STARTING REBUILD SAFE URL TESTS - UNIQUE MARKER ===")

--- a/website/views/education.py
+++ b/website/views/education.py
@@ -10,6 +10,7 @@ from django.views.decorators.http import require_GET, require_POST
 
 from website.decorators import instructor_required
 from website.models import Course, Enrollment, Lecture, LectureStatus, Section, Tag, UserProfile
+from website.utils import validate_file_type
 
 
 def education_home(request):
@@ -495,7 +496,16 @@ def create_or_update_course(request):
                 return JsonResponse(
                     {"success": False, "message": f"{', '.join(missing_fields)} is required"}, status=400
                 )
-
+            if thumbnail:
+                is_valid, error_message = validate_file_type(
+                    request,
+                    "thumbnail",
+                    allowed_extensions=["jpg", "jpeg", "png"],
+                    allowed_mime_types=["image/jpeg", "image/png"],
+                    max_size=5 * 1024 * 1024,  # 5MB
+                )
+                if not is_valid:
+                    return JsonResponse({"success": False, "message": error_message}, status=400)
             user = request.user
             user_profile = UserProfile.objects.get(user=user)
 


### PR DESCRIPTION
fixes #3965
By taking file type and mime type validation as argument for validate_file_type it checks and returns msg if success or failed.
![image](https://github.com/user-attachments/assets/4d9e7cb8-cf3e-41ef-842f-3f5b2acb12ee)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced file upload validation to ensure that only files with allowed extensions, MIME types, and sizes (e.g., for course thumbnail images) are accepted.
  
- **Tests**
  - Introduced automated tests covering scenarios for valid uploads, invalid file formats, and the absence of a file to verify the new validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->