### PR TITLE
An error message is added if user enters wrong credentials while login and the UI of /accounts/confirm-email page is fixed

### DIFF
--- a/blt/settings.py
+++ b/blt/settings.py
@@ -343,7 +343,7 @@ else:
 
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_USERNAME_REQUIRED = True
-ACCOUNT_AUTHENTICATION_METHOD = "email"
+ACCOUNT_AUTHENTICATION_METHOD = "username_email"
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 ACCOUNT_FORMS = {"signup": "website.forms.SignupFormWithCaptcha"}
 

--- a/blt/settings.py
+++ b/blt/settings.py
@@ -343,7 +343,7 @@ else:
 
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_USERNAME_REQUIRED = True
-ACCOUNT_AUTHENTICATION_METHOD = "username_email"
+ACCOUNT_AUTHENTICATION_METHOD = "email"
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 ACCOUNT_FORMS = {"signup": "website.forms.SignupFormWithCaptcha"}
 

--- a/blt/settings.py
+++ b/blt/settings.py
@@ -342,8 +342,7 @@ else:
     DATABASES["default"] = dj_database_url.config(conn_max_age=0, ssl_require=False)
 
 ACCOUNT_EMAIL_REQUIRED = True
-ACCOUNT_USERNAME_REQUIRED = True
-ACCOUNT_AUTHENTICATION_METHOD = "username_email"
+ACCOUNT_AUTHENTICATION_METHOD = "email"
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 ACCOUNT_FORMS = {"signup": "website.forms.SignupFormWithCaptcha"}
 

--- a/blt/settings.py
+++ b/blt/settings.py
@@ -343,6 +343,7 @@ else:
 
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_USERNAME_REQUIRED = True
+ACCOUNT_AUTHENTICATION_METHOD = "username_email"
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 ACCOUNT_FORMS = {"signup": "website.forms.SignupFormWithCaptcha"}
 

--- a/website/templates/account/email_confirm.html
+++ b/website/templates/account/email_confirm.html
@@ -38,6 +38,14 @@
                     {% if confirmation.email_address.verified %}
                         <!-- Already Verified -->
                         <div class="text-green-600 mb-6">
+                            <div class="mx-auto mb-4 w-16 h-16 bg-green-100 rounded-full flex items-center justify-center">
+                                <svg class="w-8 h-8 text-green-600"
+                                     fill="none"
+                                     stroke="currentColor"
+                                     viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                                </svg>
+                            </div>
                             <p class="text-lg font-semibold mb-2">{% trans "Email Already Verified" %}</p>
                             <p class="text-gray-600 dark:text-gray-400">
                                 {% blocktrans with confirmation.email_address.email as email %}Your email address {{ email }} has already been confirmed.{% endblocktrans %}
@@ -53,6 +61,24 @@
                             <p class="mb-4">
                                 {% blocktrans with confirmation.email_address.email as email %}Please confirm that <strong class="text-gray-900 dark:text-gray-100">{{ email }}</strong> is an email address for user {{ confirmation.email_address.user }}.{% endblocktrans %}
                             </p>
+                            <!-- Spam Folder Reminder -->
+                            <div class="mt-4 p-4 bg-blue-50 dark:bg-gray-700 border border-blue-200 dark:border-gray-600 rounded-md">
+                                <div class="flex items-start">
+                                    <svg class="w-5 h-5 text-blue-600 dark:text-blue-400 mt-0.5 mr-3 flex-shrink-0"
+                                         fill="none"
+                                         stroke="currentColor"
+                                         viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z">
+                                        </path>
+                                    </svg>
+                                    <div>
+                                        <p class="text-sm font-semibold text-blue-900 dark:text-blue-300 mb-1">{% trans "Can't find the email?" %}</p>
+                                        <p class="text-xs text-blue-800 dark:text-blue-400">
+                                            {% trans "Check your spam or junk folder. Sometimes our emails get filtered there." %}
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                         <form method="post"
                               action="{% url 'account_confirm_email' confirmation.key %}">
@@ -63,7 +89,7 @@
                             </button>
                         </form>
                         <a href="{% url 'home' %}"
-                           class="w-full inline-block px-4 py-2 text-lg font-semibold text-gray-700 dark:text-gray-300 bg-gray-200 dark:bg-gray-700 rounded-md shadow hover:bg-gray-300 focus:outline-none focus:ring-gray-200 focus:ring-4 transition-colors duration-300 text-center">
+                           class="w-full inline-block px-4 py-2 text-lg font-semibold text-gray-700 dark:text-gray-300 bg-gray-200 dark:bg-gray-700 rounded-md shadow hover:bg-gray-300 dark:hover:bg-gray-600 focus:outline-none focus:ring-gray-200 focus:ring-4 transition-colors duration-300 text-center">
                             {% trans "Cancel" %}
                         </a>
                     {% endif %}
@@ -83,14 +109,34 @@
                         <p class="text-gray-600 dark:text-gray-400 mb-4">
                             {% trans "This email confirmation link expired or is invalid. Please request a new verification email." %}
                         </p>
+                        <!-- Spam Folder Reminder for invalid links -->
+                        <div class="mt-4 p-4 bg-blue-50 dark:bg-gray-700 border border-blue-200 dark:border-gray-600 rounded-md text-left">
+                            <div class="flex items-start">
+                                <svg class="w-5 h-5 text-blue-600 dark:text-blue-400 mt-0.5 mr-3 flex-shrink-0"
+                                     fill="none"
+                                     stroke="currentColor"
+                                     viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z">
+                                    </path>
+                                </svg>
+                                <div>
+                                    <p class="text-sm font-semibold text-blue-900 dark:text-blue-300 mb-1">{% trans "Helpful Tips" %}</p>
+                                    <ul class="text-xs text-blue-800 dark:text-blue-400 list-disc list-inside space-y-1">
+                                        <li>{% trans "Check your spam or junk folder for verification emails" %}</li>
+                                        <li>{% trans "Verification links expire after a certain time for security" %}</li>
+                                        <li>{% trans "You can request a new verification email anytime" %}</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                     <div class="space-y-3">
                         <a href="{% url 'account_email' %}"
                            class="w-full inline-block px-4 py-2 text-lg font-semibold text-white bg-red-500 rounded-md shadow hover:bg-red-600 focus:outline-none focus:ring-red-200 focus:ring-4 transition-colors duration-300 text-center">
-                            {% trans "Request New Verification Email" %}
+                            {% trans "Resend Verification Email" %}
                         </a>
                         <a href="{% url 'home' %}"
-                           class="w-full inline-block px-4 py-2 text-lg font-semibold text-gray-700 dark:text-gray-300 bg-gray-200 dark:bg-gray-700 rounded-md shadow hover:bg-gray-300 focus:outline-none focus:ring-gray-200 focus:ring-4 transition-colors duration-300 text-center">
+                           class="w-full inline-block px-4 py-2 text-lg font-semibold text-gray-700 dark:text-gray-300 bg-gray-200 dark:bg-gray-700 rounded-md shadow hover:bg-gray-300 dark:hover:bg-gray-600 focus:outline-none focus:ring-gray-200 focus:ring-4 transition-colors duration-300 text-center">
                             {% trans "Return to Home" %}
                         </a>
                     </div>

--- a/website/templates/account/login.html
+++ b/website/templates/account/login.html
@@ -70,9 +70,9 @@
                                name="{{ redirect_field_name }}"
                                value="{{ redirect_field_value }}" />
                     {% endif %}
-                    <!-- Email Field -->
+                    <!-- Email or Username Field -->
                     <div class="flex flex-col space-y-1">
-                        <label for="id_login" class="text-sm font-semibold text-gray-500">{% trans "Email" %}</label>
+                        <label for="id_login" class="text-sm font-semibold text-gray-500">{% trans "Email or Username" %}</label>
                         <input autofocus
                                id="id_login"
                                name="login"

--- a/website/templates/account/login.html
+++ b/website/templates/account/login.html
@@ -45,7 +45,6 @@
                     {% trans "Read our" %} <a href="{% url 'terms' %}" class="underline text-white">{% trans "terms" %}</a> {% trans "and" %} <a href="{% url 'terms' %}" class="underline text-white">{% trans "conditions" %}</a>
                 </p>
             </div>
-            
             <!-- Right Side (Login Form) -->
             <div class="p-5 bg-white dark:bg-gray-800 md:flex-1">
                 <h3 class="text-2xl font-semibold text-gray-700">{% trans "Account Login" %}</h3>

--- a/website/templates/account/login.html
+++ b/website/templates/account/login.html
@@ -45,9 +45,22 @@
                     {% trans "Read our" %} <a href="{% url 'terms' %}" class="underline text-white">{% trans "terms" %}</a> {% trans "and" %} <a href="{% url 'terms' %}" class="underline text-white">{% trans "conditions" %}</a>
                 </p>
             </div>
-            <!-- Right Side (Login Form) d -->
+            
+            <!-- Right Side (Login Form) -->
             <div class="p-5 bg-white dark:bg-gray-800 md:flex-1">
-                <h3 class="text-2xl font-semibold text-gray-700 dark:text-gray-300">{% trans "Account Login" %}</h3>
+                <h3 class="text-2xl font-semibold text-gray-700">{% trans "Account Login" %}</h3>
+                {% if form.errors %}
+                    <div class="mt-4 p-4 mb-4 text-sm text-red-700 bg-red-100 rounded-lg"
+                         role="alert">
+                        <p>{% trans "Invalid username or password." %}</p>
+                    </div>
+                {% endif %}
+                {% if messages %}
+                    {% for message in messages %}
+                        <div class="mt-4 p-4 mb-4 text-sm {% if message.tags == 'error' %}text-red-700 bg-red-100{% elif message.tags == 'success' %}text-green-700 bg-green-100{% endif %} rounded-lg"
+                             role="alert">{{ message }}</div>
+                    {% endfor %}
+                {% endif %}
                 <form class="flex flex-col space-y-4 login"
                       method="post"
                       action="{% url 'account_login' %}?next={{ request.path }}">

--- a/website/templates/account/login.html
+++ b/website/templates/account/login.html
@@ -52,7 +52,7 @@
                 {% if form.errors %}
                     <div class="mt-4 p-4 mb-4 text-sm text-red-700 bg-red-100 rounded-lg"
                          role="alert">
-                        <p>{% trans "Invalid username/email or password." %}</p>
+                        <p>{% trans "Invalid email or password." %}</p>
                     </div>
                 {% endif %}
                 {% if messages %}

--- a/website/templates/account/login.html
+++ b/website/templates/account/login.html
@@ -7,16 +7,16 @@
     Account Login | {% env 'PROJECT_NAME' %}
 {% endblock title %}
 {% block description %}
-    Log in to your account to access the bug logging tool. Enter your username and password or log in with Google or GitHub.
+    Log in to your account to access the bug logging tool. Enter your email and password or log in with Google or GitHub.
 {% endblock description %}
 {% block keywords %}
-    Account Login, Bug Logging Tool, Username, Password, Google Login, GitHub Login
+    Account Login, Bug Logging Tool, Email, Password, Google Login, GitHub Login
 {% endblock keywords %}
 {% block og_title %}
     Account Login - Access Your Bug Logging Tool
 {% endblock og_title %}
 {% block og_description %}
-    Log in to your account to access the bug logging tool. Enter your username and password or log in with Google or GitHub for a seamless experience.
+    Log in to your account to access the bug logging tool. Enter your email and password or log in with Google or GitHub for a seamless experience.
 {% endblock og_description %}
 {% block natural_content %}
     {% include "includes/sidenav.html" %}
@@ -75,7 +75,7 @@
                         <input autofocus
                                id="id_login"
                                name="login"
-                               type="text"
+                               type="email"
                                value="{{ form.login.value|default:'' }}"
                                class="px-4 py-2 w-full transition duration-300 border border-gray-300 dark:border-gray-600 rounded focus:border-transparent focus:outline-none focus:ring-4 focus:ring-red-200 dark:bg-gray-700 dark:text-white" />
                         <span class="help-block text-sm text-red-500">{{ form.login.errors }}</span>

--- a/website/templates/account/login.html
+++ b/website/templates/account/login.html
@@ -47,11 +47,11 @@
             </div>
             <!-- Right Side (Login Form) -->
             <div class="p-5 bg-white dark:bg-gray-800 md:flex-1">
-                <h3 class="text-2xl font-semibold text-gray-700">{% trans "Account Login" %}</h3>
-                {% if form.errors %}
+                <h3 class="text-2xl font-semibold text-gray-700 dark:text-gray-300">{% trans "Account Login" %}</h3>
+                {% if form.non_field_errors %}
                     <div class="mt-4 p-4 mb-4 text-sm text-red-700 bg-red-100 rounded-lg"
                          role="alert">
-                        <p>{% trans "Invalid email or password." %}</p>
+                        {% for error in form.non_field_errors %}<p>{{ error }}</p>{% endfor %}
                     </div>
                 {% endif %}
                 {% if messages %}

--- a/website/templates/account/login.html
+++ b/website/templates/account/login.html
@@ -69,9 +69,9 @@
                                name="{{ redirect_field_name }}"
                                value="{{ redirect_field_value }}" />
                     {% endif %}
-                    <!-- Email or Username Field -->
+                    <!-- Email Field -->
                     <div class="flex flex-col space-y-1">
-                        <label for="id_login" class="text-sm font-semibold text-gray-500">{% trans "Email or Username" %}</label>
+                        <label for="id_login" class="text-sm font-semibold text-gray-500">{% trans "Email" %}</label>
                         <input autofocus
                                id="id_login"
                                name="login"

--- a/website/templates/account/login.html
+++ b/website/templates/account/login.html
@@ -52,7 +52,7 @@
                 {% if form.errors %}
                     <div class="mt-4 p-4 mb-4 text-sm text-red-700 bg-red-100 rounded-lg"
                          role="alert">
-                        <p>{% trans "Invalid username or password." %}</p>
+                        <p>{% trans "Invalid username/email or password." %}</p>
                     </div>
                 {% endif %}
                 {% if messages %}
@@ -70,13 +70,13 @@
                                name="{{ redirect_field_name }}"
                                value="{{ redirect_field_value }}" />
                     {% endif %}
-                    <!-- Username Field -->
+                    <!-- Email Field -->
                     <div class="flex flex-col space-y-1">
-                        <label for="id_login"
-                               class="text-sm font-semibold text-gray-500 dark:text-gray-500">Username</label>
+                        <label for="id_login" class="text-sm font-semibold text-gray-500">{% trans "Email" %}</label>
                         <input autofocus
                                id="id_login"
                                name="login"
+                               type="text"
                                value="{{ form.login.value|default:'' }}"
                                class="px-4 py-2 w-full transition duration-300 border border-gray-300 dark:border-gray-600 rounded focus:border-transparent focus:outline-none focus:ring-4 focus:ring-red-200 dark:bg-gray-700 dark:text-white" />
                         <span class="help-block text-sm text-red-500">{{ form.login.errors }}</span>

--- a/website/templates/account/verification_sent.html
+++ b/website/templates/account/verification_sent.html
@@ -1,71 +1,61 @@
 {% extends "base.html" %}
+{% load i18n %}
 {% load static %}
 {% load custom_tags %}
-{% load i18n %}
-{% block title %}
-    Verify Your Email Address | {% env 'PROJECT_NAME' %}
-{% endblock title %}
-{% block description %}
-    Please check your email for a verification link to complete your account registration.
-{% endblock description %}
-{% block keywords %}
-    Email Verification, Account Verification, Complete Registration
-{% endblock keywords %}
-{% block og_title %}
-    Email Verification Required
-{% endblock og_title %}
-{% block og_description %}
-    Please check your email for a verification link to complete your account registration.
-{% endblock og_description %}
+{% block header %}{% endblock %}
+{% block include_header %}{% endblock %}
 {% block natural_content %}
-    {% include "includes/sidenav.html" %}
-    <div class="flex items-center justify-center w-full min-h-screen p-4 bg-gray-100 dark:bg-gray-800">
-        <div class="w-full max-w-md bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8">
-            <div class="text-center">
-                <!-- Success Icon -->
-                <div class="mx-auto mb-6 w-16 h-16 bg-green-100 rounded-full flex items-center justify-center">
-                    <svg class="w-8 h-8 text-green-600"
-                         fill="none"
-                         stroke="currentColor"
-                         viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
-                        </path>
-                    </svg>
-                </div>
-                <!-- Heading -->
-                <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">{% trans "Verify Your Email Address" %}</h1>
-                <!-- Message -->
-                <div class="text-gray-600 dark:text-gray-400 mb-6 space-y-3">
-                    <p>
-                        {% blocktrans %}We have sent an email to you for verification. Follow the link provided to finalize the signup process.{% endblocktrans %}
-                    </p>
-                    <p>
-                        {% blocktrans %}If you do not see the verification email in your main inbox, check your spam folder.{% endblocktrans %}
-                    </p>
-                    <p class="text-sm text-gray-500 dark:text-gray-500">
-                        {% blocktrans %}Please contact us if you do not receive the verification email within a few minutes.{% endblocktrans %}
-                    </p>
-                </div>
-                <!-- Action Buttons -->
-                <div class="space-y-3">
+    <div class="flex items-center min-h-screen py-6 px-4 bg-gray-100 lg:justify-center">
+        <div class="flex flex-col overflow-hidden bg-white rounded-md shadow-lg max md:flex-row md:flex-1 lg:max-w-screen-sm">
+            <!-- Left Side (Branding and Info) -->
+            <div class="p-4 py-6 text-white bg-red-500 md:w-80 md:flex-shrink-0 md:flex md:flex-col md:items-center md:justify-evenly">
+                <div class="my-2 text-4xl font-bold tracking-wider text-center">
                     <a href="{% url 'home' %}"
-                       class="w-full inline-block px-4 py-2 text-lg font-semibold text-white bg-red-500 rounded-md shadow hover:bg-red-600 focus:outline-none focus:ring-red-200 focus:ring-4 transition-colors duration-300 text-center">
-                        {% trans "Return to Home" %}
-                    </a>
-                    <a href="{% url 'account_login' %}"
-                       class="w-full inline-block px-4 py-2 text-lg font-semibold text-gray-700 dark:text-gray-300 bg-gray-200 dark:bg-gray-700 rounded-md shadow hover:bg-gray-300 focus:outline-none focus:ring-gray-200 focus:ring-4 transition-colors duration-300 text-center">
-                        {% trans "Sign In" %}
-                    </a>
+                       class="hover:no-underline text-white hover:text-white">{% env 'PROJECT_NAME' %}</a>
                 </div>
-                <!-- Resend Email Link -->
-                <div class="mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">
-                    <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">{% trans "Didn't receive the email?" %}</p>
-                    <a href="{% url 'account_email' %}"
-                       class="text-red-500 hover:text-red-600 font-medium text-sm underline">
-                        {% trans "Resend verification email" %}
-                    </a>
+                <p class="mt-4 font-normal text-center text-white text-xl md:mt-0">
+                    {% env 'PROJECT_NAME' %} {% trans "is a bug logging tool to report issues and get points, Organizations are held accountable" %}.
+                </p>
+                <p class="mt-6 font-normal text-center text-white text-lg md:mt-0">
+                    {% trans "Thank you for joining our community!" %}
+                </p>
+            </div>
+            <!-- Right Side (Verification Content) -->
+            <div class="p-5 bg-white md:flex-1">
+                <h3 class="text-2xl text-center font-semibold text-gray-700 mb-6">{% trans "Check Your Email" %}</h3>
+                <div class="flex justify-center mb-8">
+                    <div class="relative">
+                        <div class="absolute -inset-2">
+                            <div class="w-full h-full mx-auto opacity-30 blur-lg filter bg-gradient-to-r from-red-400 to-red-600"></div>
+                        </div>
+                        <svg class="relative h-16 w-16 text-red-500"
+                             fill="none"
+                             stroke="currentColor"
+                             viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 19v-8.93a2 2 0 01.89-1.664l7-4.666a2 2 0 012.22 0l7 4.666A2 2 0 0121 10.07V19M3 19a2 2 0 002 2h14a2 2 0 002-2M3 19l6.75-4.5M21 19l-6.75-4.5M3 10l6.75 4.5M21 10l-6.75 4.5m0 0l-1.14.76a2 2 0 01-2.22 0l-1.14-.76">
+                            </path>
+                        </svg>
+                    </div>
+                </div>
+                <div class="space-y-6">
+                    <div class="text-center">
+                        <p class="text-gray-600 mb-2">{% trans "We've sent a verification email to your inbox." %}</p>
+                        <p class="text-sm text-gray-500">{% trans "Please click the link in the email to confirm your email address." %}</p>
+                    </div>
+                    <div class="space-y-4">
+                        <div class="grid grid-cols-2 gap-4">
+                            <a href="{% url 'account_login' %}"
+                               class="flex items-center justify-center px-4 py-2 text-lg font-semibold text-white transition-colors duration-300 bg-red-500 rounded-md shadow hover:bg-red-600 focus:outline-none focus:ring-red-200 focus:ring-4">
+                                {% trans "Login" %}
+                            </a>
+                            <a href="{% url 'account_signup' %}"
+                               class="flex items-center justify-center px-4 py-2 text-lg font-semibold text-white transition-colors duration-300 bg-red-500 rounded-md shadow hover:bg-red-600 focus:outline-none focus:ring-red-200 focus:ring-4">
+                                {% trans "Sign Up" %}
+                            </a>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
-{% endblock natural_content %}
+{% endblock %}

--- a/website/templates/account/verification_sent.html
+++ b/website/templates/account/verification_sent.html
@@ -2,6 +2,21 @@
 {% load i18n %}
 {% load static %}
 {% load custom_tags %}
+{% block title %}
+    {% trans "Verify Your Email" %} - {% env 'PROJECT_NAME' %}
+{% endblock %}
+{% block description %}
+    {% trans "Please check your email to verify your account" %}
+{% endblock %}
+{% block keywords %}
+    {% trans "email verification, account verification, confirm email" %}
+{% endblock %}
+{% block og_title %}
+    {% trans "Verify Your Email" %} - {% env 'PROJECT_NAME' %}
+{% endblock %}
+{% block og_description %}
+    {% trans "Please check your email to verify your account" %}
+{% endblock %}
 {% block header %}{% endblock %}
 {% block include_header %}{% endblock %}
 {% block natural_content %}
@@ -43,6 +58,13 @@
                         <p class="text-sm text-gray-500">{% trans "Please click the link in the email to confirm your email address." %}</p>
                     </div>
                     <div class="space-y-4">
+                        <div class="text-center mb-4">
+                            <p class="text-sm text-gray-500 mb-2">{% trans "Didn't receive the email?" %}</p>
+                            <a href="{% url 'account_email' %}"
+                               class="text-red-500 hover:text-red-600 underline text-sm font-medium">
+                                {% trans "Resend verification email" %}
+                            </a>
+                        </div>
                         <div class="grid grid-cols-2 gap-4">
                             <a href="{% url 'account_login' %}"
                                class="flex items-center justify-center px-4 py-2 text-lg font-semibold text-white transition-colors duration-300 bg-red-500 rounded-md shadow hover:bg-red-600 focus:outline-none focus:ring-red-200 focus:ring-4">

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -124,10 +124,8 @@
         {% block style %}
         {% endblock style %}
     </head>
-    <body class="relative min-h-[100vh] flex flex-col bg-white font-['Inter'] bg-gray-50">
-        {% block include_header %}
-            {% include "includes/header.html" %}
-        {% endblock %}
+    <body class="relative min-h-[100vh] flex flex-col bg-white dark:bg-gray-900 font-['Inter'] text-gray-900 dark:text-gray-100 transition-colors duration-300">
+        {% include "includes/header.html" %}
         <div class="w-full h-[50px]"></div>
         <!-- Main content starts here -->
         <main class="min-h-screen pb-[70px] mt-[20px]">

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -124,8 +124,10 @@
         {% block style %}
         {% endblock style %}
     </head>
-    <body class="relative min-h-[100vh] flex flex-col bg-white dark:bg-gray-900 font-['Inter'] text-gray-900 dark:text-gray-100 transition-colors duration-300">
-        {% include "includes/header.html" %}
+    <body class="relative min-h-[100vh] flex flex-col bg-white font-['Inter'] bg-gray-50">
+        {% block include_header %}
+            {% include "includes/header.html" %}
+        {% endblock %}
         <div class="w-full h-[50px]"></div>
         <!-- Main content starts here -->
         <main class="min-h-screen pb-[70px] mt-[20px]">

--- a/website/test_feed.py
+++ b/website/test_feed.py
@@ -59,7 +59,7 @@ class ActivityFeedTests(TestCase):
 
     def test_delete_button_not_visible_to_regular_user(self):
         """Test that delete button is not visible to regular users."""
-        self.client.login(username="testuser", password="testpass123")
+        self.client.login(email="test@example.com", password="testpass123")
         url = reverse("feed")
         response = self.client.get(url)
 
@@ -68,7 +68,7 @@ class ActivityFeedTests(TestCase):
 
     def test_delete_button_visible_to_superuser(self):
         """Test that delete button is visible to superusers."""
-        self.client.login(username="admin", password="adminpass123")
+        self.client.login(email="admin@example.com", password="adminpass123")
         url = reverse("feed")
         response = self.client.get(url)
 
@@ -77,7 +77,7 @@ class ActivityFeedTests(TestCase):
 
     def test_regular_user_cannot_delete_activity(self):
         """Test that regular users cannot delete activities."""
-        self.client.login(username="testuser", password="testpass123")
+        self.client.login(email="test@example.com", password="testpass123")
         url = reverse("delete_activity", kwargs={"id": self.activity.id})
         response = self.client.post(url)
 
@@ -87,7 +87,7 @@ class ActivityFeedTests(TestCase):
 
     def test_superuser_can_delete_activity(self):
         """Test that superusers can delete activities."""
-        self.client.login(username="admin", password="adminpass123")
+        self.client.login(email="admin@example.com", password="adminpass123")
         url = reverse("delete_activity", kwargs={"id": self.activity.id})
         response = self.client.post(url)
 

--- a/website/tests/test_adventure.py
+++ b/website/tests/test_adventure.py
@@ -12,7 +12,7 @@ class AdventureListViewTest(TestCase):
 
     def setUp(self):
         """Set up test data."""
-        self.user = User.objects.create_user(username="testuser", password="testpass123")
+        self.user = User.objects.create_user(username="testuser", email="test@example.com", password="testpass123")
         self.adventure = Adventure.objects.create(
             title="Test Adventure",
             slug="test-adventure",
@@ -24,7 +24,7 @@ class AdventureListViewTest(TestCase):
 
     def test_adventure_list_view_without_user_progress(self):
         """Test that adventure list view works without user progress."""
-        self.client.login(username="testuser", password="testpass123")
+        self.client.login(email="test@example.com", password="testpass123")
         response = self.client.get(reverse("adventure_list"))
         self.assertEqual(response.status_code, 200)
         self.assertIn("adventures", response.context)
@@ -35,7 +35,7 @@ class AdventureListViewTest(TestCase):
         UserAdventureProgress.objects.create(user=self.user, adventure=self.adventure)
 
         # Login and access the view
-        self.client.login(username="testuser", password="testpass123")
+        self.client.login(email="test@example.com", password="testpass123")
         response = self.client.get(reverse("adventure_list"))
 
         # Should not raise TypeError: Direct assignment to the reverse side of a related set is prohibited

--- a/website/tests/test_api.py
+++ b/website/tests/test_api.py
@@ -129,7 +129,7 @@ class APITests(APITestCase):
         self.token = response.json()["key"]
 
         payload = {
-            "username": self.USERNAME.lower(),
+            "username": self.EMAIL,
             "password": self.PASS,
         }
         response = self.client.post(self.login_url, data=payload)

--- a/website/tests/test_api.py
+++ b/website/tests/test_api.py
@@ -115,7 +115,7 @@ class APITests(APITestCase):
 
     def test_login_by_email(self):
         payload = {
-            "login": self.EMAIL,
+            "email": self.EMAIL,
             "password": self.PASS,
         }
 
@@ -129,7 +129,7 @@ class APITests(APITestCase):
         self.token = response.json()["key"]
 
         payload = {
-            "login": self.EMAIL,
+            "email": self.EMAIL,
             "password": self.PASS,
         }
         response = self.client.post(self.login_url, data=payload)
@@ -156,7 +156,7 @@ class APITests(APITestCase):
 
         # Now try to login to get the key
         login_payload = {
-            "login": self.EMAIL,
+            "email": self.EMAIL,
             "password": self.PASS,
         }
         login_response = self.client.post(self.login_url, data=login_payload)

--- a/website/tests/test_api.py
+++ b/website/tests/test_api.py
@@ -156,7 +156,7 @@ class APITests(APITestCase):
 
         # Now try to login to get the key
         login_payload = {
-            "username": self.USERNAME.lower(),
+            "email": self.EMAIL,
             "password": self.PASS,
         }
         login_response = self.client.post(self.login_url, data=login_payload)

--- a/website/tests/test_api.py
+++ b/website/tests/test_api.py
@@ -115,7 +115,7 @@ class APITests(APITestCase):
 
     def test_login_by_email(self):
         payload = {
-            "username": self.USERNAME.lower(),
+            "email": self.EMAIL,
             "password": self.PASS,
         }
 

--- a/website/tests/test_api.py
+++ b/website/tests/test_api.py
@@ -129,7 +129,7 @@ class APITests(APITestCase):
         self.token = response.json()["key"]
 
         payload = {
-            "username": self.EMAIL,
+            "email": self.EMAIL,
             "password": self.PASS,
         }
         response = self.client.post(self.login_url, data=payload)

--- a/website/tests/test_api.py
+++ b/website/tests/test_api.py
@@ -115,7 +115,7 @@ class APITests(APITestCase):
 
     def test_login_by_email(self):
         payload = {
-            "email": self.EMAIL,
+            "login": self.EMAIL,
             "password": self.PASS,
         }
 
@@ -129,7 +129,7 @@ class APITests(APITestCase):
         self.token = response.json()["key"]
 
         payload = {
-            "email": self.EMAIL,
+            "login": self.EMAIL,
             "password": self.PASS,
         }
         response = self.client.post(self.login_url, data=payload)
@@ -156,7 +156,7 @@ class APITests(APITestCase):
 
         # Now try to login to get the key
         login_payload = {
-            "email": self.EMAIL,
+            "login": self.EMAIL,
             "password": self.PASS,
         }
         login_response = self.client.post(self.login_url, data=login_payload)

--- a/website/tests/test_bidding.py
+++ b/website/tests/test_bidding.py
@@ -26,7 +26,7 @@ class BiddingTestCase(TestCase):
     def test_add_bid_authenticated_user(self):
         """Test adding a bid with an authenticated user."""
         # Log in the user
-        self.client.login(username="testuser", password="testpassword")
+        self.client.login(email="test@example.com", password="testpassword")
 
         # Make a POST request to the bidding endpoint
         response = self.client.post(
@@ -67,7 +67,7 @@ class BiddingTestCase(TestCase):
     def test_add_bid_with_github_username(self):
         """Test adding a bid with a GitHub username that doesn't match a user in the system."""
         # Log in the user
-        self.client.login(username="testuser", password="testpassword")
+        self.client.login(email="test@example.com", password="testpassword")
 
         # Make a POST request with a different GitHub username
         github_username = "github_user"
@@ -92,7 +92,7 @@ class BiddingTestCase(TestCase):
 
     def test_view_bidding_page(self):
         """Test that the bidding page can be viewed successfully."""
-        self.client.login(username="testuser", password="testpassword")
+        self.client.login(email="test@example.com", password="testpassword")
         response = self.client.get(reverse("BiddingData"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "bidding.html")
@@ -128,7 +128,7 @@ class BiddingTestCase(TestCase):
     def test_add_bid_with_github_url_in_profile(self):
         """Test that a bid can be added using the GitHub username from the user's profile."""
         # Login the user
-        self.client.login(username="testuser", password="testpassword")
+        self.client.login(email="test@example.com", password="testpassword")
 
         # Set GitHub URL in the user's profile
         user = User.objects.get(username="testuser")

--- a/website/tests/test_bitcoin_slack_notification.py
+++ b/website/tests/test_bitcoin_slack_notification.py
@@ -366,9 +366,10 @@ class BaconSubmissionSlackNotificationTests(TestCase):
         # Create user with markdown characters in username
         user_with_markdown = User.objects.create_user(
             username="user_with_*bold*_underscore_`code`",
+            email="markdown@example.com",
             password="testpass123",
         )
-        self.client.login(email=user_with_markdown.email, password="testpass123")
+        self.client.force_login(user_with_markdown)
 
         mock_client = MagicMock()
         mock_webclient_class.return_value = mock_client

--- a/website/tests/test_bitcoin_slack_notification.py
+++ b/website/tests/test_bitcoin_slack_notification.py
@@ -15,8 +15,8 @@ class BaconSubmissionSlackNotificationTests(TestCase):
     def setUp(self):
         """Set up test data"""
         self.client = Client()
-        self.user = User.objects.create_user(username="testuser", password="testpass123")
-        self.client.login(username="testuser", password="testpass123")
+        self.user = User.objects.create_user(username="testuser", email="test@example.com", password="testpass123")
+        self.client.login(email="test@example.com", password="testpass123")
 
         # Create OWASP BLT organization
         self.organization = Organization.objects.create(
@@ -368,7 +368,7 @@ class BaconSubmissionSlackNotificationTests(TestCase):
             username="user_with_*bold*_underscore_`code`",
             password="testpass123",
         )
-        self.client.login(username=user_with_markdown.username, password="testpass123")
+        self.client.login(email=user_with_markdown.email, password="testpass123")
 
         mock_client = MagicMock()
         mock_webclient_class.return_value = mock_client

--- a/website/tests/test_bugs_list.py
+++ b/website/tests/test_bugs_list.py
@@ -29,7 +29,10 @@ class BugsListTest(TestCase):
 
         # Create some test issues
         self.visible_issue = Issue.objects.create(
-            url="http://example.com/visible", description="Visible Test Issue", user=self.verified_user, is_hidden=False
+            url="http://example.com/visible",
+            description="Visible Test Issue",
+            user=self.verified_user,
+            is_hidden=False,
         )
 
         self.hidden_issue = Issue.objects.create(
@@ -74,7 +77,7 @@ class BugsListTest(TestCase):
 
     def test_bugs_list_verified_user(self):
         """Test bugs_list page for verified users"""
-        self.client.login(username="verified_user", password="testpass123")
+        self.client.login(email="verified@example.com", password="testpass123")
         url = reverse("issues")
         response = self.client.get(url)
 
@@ -96,7 +99,7 @@ class BugsListTest(TestCase):
 
     def test_bugs_list_unverified_user(self):
         """Test bugs_list page for unverified users"""
-        self.client.login(username="unverified_user", password="testpass123")
+        self.client.login(email="unverified@example.com", password="testpass123")
         url = reverse("issues")
         response = self.client.get(url)
 

--- a/website/tests/test_core.py
+++ b/website/tests/test_core.py
@@ -11,9 +11,9 @@ from website.models import ForumCategory, ForumPost, GitHubIssue, Repo, UserProf
 class ForumTests(TestCase):
     def setUp(self):
         self.client = Client()
-        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.user = User.objects.create_user(username="testuser", email="test@example.com", password="testpass")
         self.category = ForumCategory.objects.create(name="Test Category", description="Test Description")
-        self.client.login(username="testuser", password="testpass")
+        self.client.login(email="test@example.com", password="testpass")
 
         self.post_data = {"title": "Test Post", "category": self.category.id, "description": "Test Description"}
 

--- a/website/tests/test_issues.py
+++ b/website/tests/test_issues.py
@@ -11,10 +11,10 @@ from website.models import Issue, UserProfile
 @override_settings(STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage")
 class IssueCommentTests(TestCase):
     def setUp(self):
-        self.user = User.objects.create_user(username="testuser", password="12345")
+        self.user = User.objects.create_user(username="testuser", email="test@example.com", password="12345")
         self.user_profile, created = UserProfile.objects.get_or_create(user=self.user)
         self.issue = Issue.objects.create(url="http://example.com", description="Test Issue", user=self.user)
-        self.client.login(username="testuser", password="12345")
+        self.client.login(email="test@example.com", password="12345")
 
     def test_add_comment(self):
         url = reverse("comment_on_content", args=[self.issue.pk])

--- a/website/tests/test_main.py
+++ b/website/tests/test_main.py
@@ -132,7 +132,7 @@ class MySeleniumTests(LiveServerTestCase):
         self.assertTrue(EmailAddress.objects.filter(user=user, verified=True).exists())
 
     @override_settings(DEBUG=True)
-    def test_login_email(self):
+    def test_login(self):
         user_email = "bugbug@bugbug.com"
         user_name = "bugbug"
         self.selenium.get("%s%s" % (self.live_server_url, "/accounts/login/"))

--- a/website/tests/test_main.py
+++ b/website/tests/test_main.py
@@ -135,6 +135,7 @@ class MySeleniumTests(LiveServerTestCase):
     def test_login(self):
         user_email = "bugbug@bugbug.com"
         user_name = "bugbug"
+        self._ensure_bugbug_user_verified()
         self.selenium.get("%s%s" % (self.live_server_url, "/accounts/login/"))
         self.selenium.find_element(By.NAME, "login").send_keys(user_email)
         self.selenium.find_element(By.NAME, "password").send_keys("secret")

--- a/website/tests/test_main.py
+++ b/website/tests/test_main.py
@@ -133,6 +133,7 @@ class MySeleniumTests(LiveServerTestCase):
 
     @override_settings(DEBUG=True)
     def test_login(self):
+        user = User.objects.create_user(username="bugbugbug", email="bugbugbug@bugbug.com", password="secret")
         # Email verification is now handled in setUp
         self.selenium.get("%s%s" % (self.live_server_url, "/accounts/login/"))
         self.selenium.find_element("name", "login").send_keys("bugbugbug@bugbug.com")

--- a/website/tests/test_main.py
+++ b/website/tests/test_main.py
@@ -11,7 +11,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from selenium import webdriver
-from selenium.common.exceptions import ElementClickInterceptedException
+from selenium.common.exceptions import ElementClickInterceptedException, TimeoutException
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC

--- a/website/tests/test_main.py
+++ b/website/tests/test_main.py
@@ -265,28 +265,21 @@ class MySeleniumTests(LiveServerTestCase):
     def _ensure_bugbug_user_verified(self):
         """Helper method to create and verify the bugbug test user."""
         from allauth.account.models import EmailAddress
-        from django.db import transaction
 
-        with transaction.atomic():
-            # Get or create the bugbug user
-            bugbug_user, created = User.objects.get_or_create(
-                username="bugbug", defaults={"email": "bugbug@bugbug.com"}
-            )
-            if created:
-                bugbug_user.set_password("secret")
-                bugbug_user.save()
+        # Get or create the bugbug user
+        bugbug_user, created = User.objects.get_or_create(username="bugbug", defaults={"email": "bugbug@bugbug.com"})
+        if created:
+            bugbug_user.set_password("secret")
+            bugbug_user.save()
 
-            # Verify the email
-            email_address, created = EmailAddress.objects.get_or_create(
-                user=bugbug_user, email="bugbug@bugbug.com", defaults={"verified": True, "primary": True}
-            )
-            if not created:
-                email_address.verified = True
-                email_address.primary = True
-                email_address.save()
-
-        # Force transaction commit by accessing the database
-        User.objects.get(username="bugbug")
+        # Verify the email
+        email_address, created = EmailAddress.objects.get_or_create(
+            user=bugbug_user, email="bugbug@bugbug.com", defaults={"verified": True, "primary": True}
+        )
+        if not created:
+            email_address.verified = True
+            email_address.primary = True
+            email_address.save()
 
     def setUp(self):
         super().setUp()

--- a/website/tests/test_main.py
+++ b/website/tests/test_main.py
@@ -155,9 +155,21 @@ class MySeleniumTests(LiveServerTestCase):
         self.assertTrue(EmailAddress.objects.filter(user=user, verified=True).exists())
 
     @override_settings(DEBUG=True)
-    def test_login(self):
+    def test_login_email(self):
         self.selenium.get("%s%s" % (self.live_server_url, "/accounts/login/"))
         self.selenium.find_element("name", "login").send_keys(self.user.email)
+        self.selenium.find_element("name", "password").send_keys("secret")
+        self.selenium.find_element("name", "login_button").click()
+        WebDriverWait(self.selenium, 30).until(EC.presence_of_element_located((By.TAG_NAME, "body")))
+        body = self.selenium.find_element("tag name", "body")
+        # Check for current header format: @username and separate Points display
+        self.assertIn(f"@{self.user.username.split('_')[0]}", body.text)
+        self.assertIn("0 Points", body.text)
+        
+    @override_settings(DEBUG=True)
+    def test_login_username(self):
+        self.selenium.get("%s%s" % (self.live_server_url, "/accounts/login/"))
+        self.selenium.find_element("name", "login").send_keys(self.user.username)
         self.selenium.find_element("name", "password").send_keys("secret")
         self.selenium.find_element("name", "login_button").click()
         WebDriverWait(self.selenium, 30).until(EC.presence_of_element_located((By.TAG_NAME, "body")))

--- a/website/tests/test_main.py
+++ b/website/tests/test_main.py
@@ -11,7 +11,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from selenium import webdriver
-from selenium.common.exceptions import ElementClickInterceptedException, TimeoutException
+from selenium.common.exceptions import ElementClickInterceptedException
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC

--- a/website/tests/test_main.py
+++ b/website/tests/test_main.py
@@ -142,7 +142,7 @@ class MySeleniumTests(LiveServerTestCase):
         WebDriverWait(self.selenium, 30).until(EC.presence_of_element_located((By.TAG_NAME, "body")))
         body = self.selenium.find_element("tag name", "body")
         # Check for current header format: @username and separate Points display
-        self.assertIn(f"@{user_name.split('_')[0]}", body.text)
+        self.assertIn(f"@{user_name}", body.text)
         self.assertIn("0 Points", body.text)
 
     @override_settings(DEBUG=True)
@@ -155,7 +155,7 @@ class MySeleniumTests(LiveServerTestCase):
         WebDriverWait(self.selenium, 30).until(EC.presence_of_element_located((By.TAG_NAME, "body")))
         body = self.selenium.find_element("tag name", "body")
         # Check for current header format: @username and separate Points display
-        self.assertIn(f"@{user_name.split('_')[0]}", body.text)
+        self.assertIn(f"@{user_name}", body.text)
         self.assertIn("0 Points", body.text)
 
     @override_settings(DEBUG=True, IS_TEST=True)

--- a/website/tests/test_main.py
+++ b/website/tests/test_main.py
@@ -134,6 +134,9 @@ class MySeleniumTests(LiveServerTestCase):
     @override_settings(DEBUG=True)
     def test_login(self):
         user = User.objects.create_user(username="bugbugbug", email="bugbugbug@bugbug.com", password="secret")
+        from allauth.account.models import EmailAddress
+
+        EmailAddress.objects.create(user=user, email="bugbugbug@bugbug.com", verified=True, primary=True)
         # Email verification is now handled in setUp
         self.selenium.get("%s%s" % (self.live_server_url, "/accounts/login/"))
         self.selenium.find_element("name", "login").send_keys("bugbugbug@bugbug.com")

--- a/website/tests/test_main.py
+++ b/website/tests/test_main.py
@@ -136,24 +136,11 @@ class MySeleniumTests(LiveServerTestCase):
         user_email = "bugbug@bugbug.com"
         user_name = "bugbug"
         self.selenium.get("%s%s" % (self.live_server_url, "/accounts/login/"))
-        self.selenium.find_element("name", "login").send_keys(user_email)
-        self.selenium.find_element("name", "password").send_keys("secret")
-        self.selenium.find_element("name", "login_button").click()
+        self.selenium.find_element(By.NAME, "login").send_keys(user_email)
+        self.selenium.find_element(By.NAME, "password").send_keys("secret")
+        self.selenium.find_element(By.NAME, "login_button").click()
         WebDriverWait(self.selenium, 30).until(EC.presence_of_element_located((By.TAG_NAME, "body")))
-        body = self.selenium.find_element("tag name", "body")
-        # Check for current header format: @username and separate Points display
-        self.assertIn(f"@{user_name}", body.text)
-        self.assertIn("0 Points", body.text)
-
-    @override_settings(DEBUG=True)
-    def test_login_username(self):
-        user_name = "bugbug"
-        self.selenium.get("%s%s" % (self.live_server_url, "/accounts/login/"))
-        self.selenium.find_element("name", "login").send_keys(user_name)
-        self.selenium.find_element("name", "password").send_keys("secret")
-        self.selenium.find_element("name", "login_button").click()
-        WebDriverWait(self.selenium, 30).until(EC.presence_of_element_located((By.TAG_NAME, "body")))
-        body = self.selenium.find_element("tag name", "body")
+        body = self.selenium.find_element(By.TAG_NAME, "body")
         # Check for current header format: @username and separate Points display
         self.assertIn(f"@{user_name}", body.text)
         self.assertIn("0 Points", body.text)
@@ -164,7 +151,7 @@ class MySeleniumTests(LiveServerTestCase):
 
         # Log in
         self.selenium.get(f"{self.live_server_url}/accounts/login/")
-        self.selenium.find_element(By.NAME, "login").send_keys("bugbug")
+        self.selenium.find_element(By.NAME, "login").send_keys("bugbug@bugbug.com")
         self.selenium.find_element(By.NAME, "password").send_keys("secret")
         self.selenium.find_element(By.NAME, "login_button").click()
 
@@ -204,7 +191,7 @@ class MySeleniumTests(LiveServerTestCase):
 
         # Log in
         self.selenium.get(f"{self.live_server_url}/accounts/login/")
-        self.selenium.find_element(By.NAME, "login").send_keys("bugbug")
+        self.selenium.find_element(By.NAME, "login").send_keys("bugbug@bugbug.com")
         self.selenium.find_element(By.NAME, "password").send_keys("secret")
         self.selenium.find_element(By.NAME, "login_button").click()
 
@@ -351,7 +338,7 @@ class RemoveUserFromIssueTest(TestCase):
 
     def test_remove_user_from_issue(self):
         # Only the issue poster can delete own issue
-        self.client.login(username="testuser", password="password")
+        self.client.login(email="test@example.com", password="password")
 
         url = reverse("remove_user_from_issue", args=[self.issue.id])
         self.client.post(url, follow=True)  # Remove unused response variable
@@ -512,7 +499,7 @@ class ProjectPageTest(TestCase):
 class OrganizationTests(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(username="testuser", password="testpass123", email="test@example.com")
-        self.client.login(username="testuser", password="testpass123")
+        self.client.login(email="test@example.com", password="testpass123")
 
     def test_create_and_list_organization(self):
         # Test organization creation

--- a/website/tests/test_main.py
+++ b/website/tests/test_main.py
@@ -132,7 +132,7 @@ class MySeleniumTests(LiveServerTestCase):
         self.assertTrue(EmailAddress.objects.filter(user=user, verified=True).exists())
 
     @override_settings(DEBUG=True)
-    def test_login_email(self):        
+    def test_login_email(self):
         user_email = "bugbug@bugbug.com"
         user_name = "bugbug"
         self.selenium.get("%s%s" % (self.live_server_url, "/accounts/login/"))

--- a/website/tests/test_main.py
+++ b/website/tests/test_main.py
@@ -165,7 +165,7 @@ class MySeleniumTests(LiveServerTestCase):
         # Check for current header format: @username and separate Points display
         self.assertIn(f"@{self.user.username.split('_')[0]}", body.text)
         self.assertIn("0 Points", body.text)
-        
+
     @override_settings(DEBUG=True)
     def test_login_username(self):
         self.selenium.get("%s%s" % (self.live_server_url, "/accounts/login/"))

--- a/website/tests/test_main.py
+++ b/website/tests/test_main.py
@@ -135,7 +135,7 @@ class MySeleniumTests(LiveServerTestCase):
     def test_login(self):
         # Email verification is now handled in setUp
         self.selenium.get("%s%s" % (self.live_server_url, "/accounts/login/"))
-        self.selenium.find_element("name", "login").send_keys("bugbug")
+        self.selenium.find_element("name", "login").send_keys("bugbugbug@bugbug.com")
         self.selenium.find_element("name", "password").send_keys("secret")
         self.selenium.find_element("name", "login_button").click()
         WebDriverWait(self.selenium, 30).until(EC.presence_of_element_located((By.TAG_NAME, "body")))

--- a/website/tests/test_main.py
+++ b/website/tests/test_main.py
@@ -156,19 +156,14 @@ class MySeleniumTests(LiveServerTestCase):
 
     @override_settings(DEBUG=True)
     def test_login(self):
-        user = User.objects.create_user(username="bugbugbug", email="bugbugbug@bugbug.com", password="secret")
-        from allauth.account.models import EmailAddress
-
-        EmailAddress.objects.create(user=user, email="bugbugbug@bugbug.com", verified=True, primary=True)
-        # Email verification is now handled in setUp
         self.selenium.get("%s%s" % (self.live_server_url, "/accounts/login/"))
-        self.selenium.find_element("name", "login").send_keys("bugbugbug@bugbug.com")
+        self.selenium.find_element("name", "login").send_keys(self.user.email)
         self.selenium.find_element("name", "password").send_keys("secret")
         self.selenium.find_element("name", "login_button").click()
         WebDriverWait(self.selenium, 30).until(EC.presence_of_element_located((By.TAG_NAME, "body")))
         body = self.selenium.find_element("tag name", "body")
         # Check for current header format: @username and separate Points display
-        self.assertIn("@bugbug", body.text)
+        self.assertIn(f"@{self.user.username.split('_')[0]}", body.text)
         self.assertIn("0 Points", body.text)
 
     @override_settings(DEBUG=True, IS_TEST=True)

--- a/website/tests/test_organization.py
+++ b/website/tests/test_organization.py
@@ -122,8 +122,8 @@ class SizzleCheckInViewTests(TestCase):
     def setUp(self):
         # Create test user
         self.client = Client()
-        self.user = User.objects.create_user(username="testuser", password="testpass123", email="test@example.com")
-        self.client.login(username="testuser", password="testpass123")
+        self.user = User.objects.create_user(username="testuser", email="test@example.com", password="testpass123")
+        self.client.login(email="test@example.com", password="testpass123")
 
     def test_add_sizzle_checkin_view_loads(self):
         """Test that the add sizzle check-in view loads correctly"""

--- a/website/tests/test_project_compact_view.py
+++ b/website/tests/test_project_compact_view.py
@@ -210,7 +210,7 @@ class ProjectDeleteViewTestCase(TestCase):
 
     def test_delete_project_superuser_can_delete(self):
         """Test that superuser can delete a project"""
-        self.client.login(email="superuser@example.com", password="superpass123")
+        self.client.login(email="super@example.com", password="superpass123")
         url = reverse("delete_project", kwargs={"slug": self.project.slug})
         response = self.client.post(url)
         # Should redirect to project list
@@ -221,7 +221,7 @@ class ProjectDeleteViewTestCase(TestCase):
 
     def test_delete_project_only_allows_post(self):
         """Test that delete project only allows POST requests"""
-        self.client.login(email="superuser@example.com", password="superpass123")
+        self.client.login(email="super@example.com", password="superpass123")
         url = reverse("delete_project", kwargs={"slug": self.project.slug})
         response = self.client.get(url)
         # GET should not be allowed
@@ -231,7 +231,7 @@ class ProjectDeleteViewTestCase(TestCase):
 
     def test_delete_nonexistent_project_returns_404(self):
         """Test that deleting a non-existent project returns 404"""
-        self.client.login(email="superuser@example.com", password="superpass123")
+        self.client.login(email="super@example.com", password="superpass123")
         url = reverse("delete_project", kwargs={"slug": "nonexistent-project"})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 404)

--- a/website/tests/test_project_compact_view.py
+++ b/website/tests/test_project_compact_view.py
@@ -12,7 +12,7 @@ class ProjectCompactViewTestCase(TestCase):
         self.client = Client()
 
         # Create test user
-        self.user = User.objects.create_user(username="testuser", password="testpass123")
+        self.user = User.objects.create_user(username="testuser", email="test@example.com", password="testpass123")
 
         # Create test organization
         self.org = Organization.objects.create(
@@ -159,7 +159,9 @@ class ProjectDeleteViewTestCase(TestCase):
         self.client = Client()
 
         # Create regular user
-        self.regular_user = User.objects.create_user(username="regular_user", password="testpass123")
+        self.regular_user = User.objects.create_user(
+            username="regular_user", email="regular_user@example.com", password="testpass123"
+        )
 
         # Create superuser
         self.superuser = User.objects.create_superuser(
@@ -198,7 +200,7 @@ class ProjectDeleteViewTestCase(TestCase):
 
     def test_delete_project_requires_superuser(self):
         """Test that deleting a project requires superuser permission"""
-        self.client.login(username="regular_user", password="testpass123")
+        self.client.login(email="regular_user@example.com", password="testpass123")
         url = reverse("delete_project", kwargs={"slug": self.project.slug})
         response = self.client.post(url)
         # Regular user should be forbidden
@@ -208,7 +210,7 @@ class ProjectDeleteViewTestCase(TestCase):
 
     def test_delete_project_superuser_can_delete(self):
         """Test that superuser can delete a project"""
-        self.client.login(username="superuser", password="superpass123")
+        self.client.login(email="superuser@example.com", password="superpass123")
         url = reverse("delete_project", kwargs={"slug": self.project.slug})
         response = self.client.post(url)
         # Should redirect to project list
@@ -219,7 +221,7 @@ class ProjectDeleteViewTestCase(TestCase):
 
     def test_delete_project_only_allows_post(self):
         """Test that delete project only allows POST requests"""
-        self.client.login(username="superuser", password="superpass123")
+        self.client.login(email="superuser@example.com", password="superpass123")
         url = reverse("delete_project", kwargs={"slug": self.project.slug})
         response = self.client.get(url)
         # GET should not be allowed
@@ -229,7 +231,7 @@ class ProjectDeleteViewTestCase(TestCase):
 
     def test_delete_nonexistent_project_returns_404(self):
         """Test that deleting a non-existent project returns 404"""
-        self.client.login(username="superuser", password="superpass123")
+        self.client.login(email="superuser@example.com", password="superpass123")
         url = reverse("delete_project", kwargs={"slug": "nonexistent-project"})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 404)

--- a/website/tests/test_user_profile.py
+++ b/website/tests/test_user_profile.py
@@ -14,7 +14,7 @@ class UserProfileUpdateTest(TestCase):
         self.client = Client()
         self.user = User.objects.create_user(username="testuser", email="test@example.com", password="testpass123")
         # UserProfile is created automatically by signal
-        self.client.login(username="testuser", password="testpass123")
+        self.client.login(email="test@example.com", password="testpass123")
 
     def test_update_profile_with_valid_bch_address(self):
         """Test updating user profile with a valid BCH address"""


### PR DESCRIPTION
It resolves #4056 

The error message for the wrong credentials while login -
![Screenshot 2025-03-27 200429](https://github.com/user-attachments/assets/37eabe9c-0a5c-4a76-ad85-1e7edb255c61)

The UI of /accounts/confirm-email/ page -
![Screenshot 2025-03-27 221557](https://github.com/user-attachments/assets/2fa0beda-dd54-4726-b19b-142b27578625)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login form now labeled "Email" (translatable), accepts email input, displays non-field errors and color-coded status messages; added "Already Verified" indicator, spam-folder reminders, helpful tips, and changed action wording to "Resend Verification Email".
  * Verification page redesigned into a two-panel "Check Your Email" layout with clearer Login/Sign Up CTAs and translated metadata.
* **Chores**
  * Site authentication switched to email-based login (username not required).
* **Tests**
  * Test suite updated to use email-based authentication and ensure email-verified preconditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->