### PR TITLE
Updated GSoC contributors page

### DIFF
--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -508,6 +508,17 @@
                                 As a Python/Django mentor for OWASP BLT's GSoC 2025 program, I'll guide students in building secure web applications and bug logging tools. My focus is on helping students develop practical skills in web development and cybersecurity while contributing to open-source projects.
                             </p>
                         </div>
+                        <!-- Bishal Das -->
+                        <div class="bg-gray-50 rounded-lg p-6 hover:shadow-md transition-shadow">
+                            <div class="flex items-center mb-4">
+                                <div>
+                                    <h3 class="text-xl font-semibold text-gray-900">Bishal Das</h3>
+                                </div>
+                            </div>
+                            <p class="text-gray-700">
+                                As a Django and UI/UX mentor for OWASP BLT in GSoC 2025, I'll guide students build secure and intuitive web applications. My focus is on guiding them through real-world development—writing clean backend code, designing smooth user experiences, and understanding the basics of cybersecurity. I'm all about making open-source contributions meaningful while helping students grow their skills along the way.
+                            </p>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Closes #4130 
Updated GSoC contributors page to add myself as mentor as asked by @DonnieBLT!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded the mentor profiles on the GSoC 2025 page by adding a new section for Bishal Das, a mentor specializing in Django and UI/UX design. His profile highlights his guidance in secure web development, blending backend expertise with intuitive user experience design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->