### PR TITLE
add setup scrips for mainnet and ordinals server

### DIFF
--- a/BACON/setup-mainnet.sh
+++ b/BACON/setup-mainnet.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -euo pipefail
+echo "Starting Bitcoin Core setup..."
+
+# === Environment Variables ===
+export ARCH=x86_64
+export BITCOIN_VERSION=0.21.1
+export BITCOIN_URL="https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-${ARCH}-linux-gnu.tar.gz"
+export BITCOIN_DATA_DIR="/blockchain/bitcoin/data"
+
+# === Create bitcoin user and group ===
+echo "Creating bitcoin user and group..."
+sudo groupadd -r bitcoin || true
+sudo useradd -r -m -g bitcoin -s /bin/bash bitcoin || true
+
+# === Install dependencies ===
+echo "Installing dependencies..."
+sudo apt update
+sudo apt install -y ca-certificates gnupg gpg wget jq --no-install-recommends
+
+# === Download and verify Bitcoin Core ===
+echo "Downloading Bitcoin Core..."
+cd /tmp
+wget "https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc"
+wget -qO "bitcoin-${BITCOIN_VERSION}-${ARCH}-linux-gnu.tar.gz" "$BITCOIN_URL"
+
+# Optional: SHA256 check (manual or via gpg key import step if desired)
+echo "Expected SHA256:"
+cat SHA256SUMS.asc | grep "bitcoin-${BITCOIN_VERSION}-${ARCH}-linux-gnu.tar.gz" | awk '{ print $1 }'
+
+# === Extract and install Bitcoin Core ===
+echo "Installing Bitcoin Core to /opt/bitcoin..."
+sudo mkdir -p "/opt/bitcoin/${BITCOIN_VERSION}"
+sudo mkdir -p "${BITCOIN_DATA_DIR}"
+sudo tar -xzvf "bitcoin-${BITCOIN_VERSION}-${ARCH}-linux-gnu.tar.gz" -C "/opt/bitcoin/${BITCOIN_VERSION}" --strip-components=1 --exclude=*-qt
+sudo ln -sfn "/opt/bitcoin/${BITCOIN_VERSION}" /opt/bitcoin/current
+sudo rm -rf /tmp/*
+sudo chown -R bitcoin:bitcoin "${BITCOIN_DATA_DIR}"
+
+# === Create bitcoin.conf ===
+echo "Creating bitcoin.conf..."
+cat > bitcoin.conf.tmp <<EOF
+datadir=${BITCOIN_DATA_DIR}
+printtoconsole=1
+rpcallowip=127.0.0.1
+rpcuser=${BITCOIN_RPC_USER:-bitcoin}
+rpcpassword=${BITCOIN_RPC_PASSWORD:-$(openssl rand -hex 24)}
+testnet=1
+prune=1000
+[test]
+rpcbind=127.0.0.1
+rpcport=18332
+EOF
+
+# === Create systemd service ===
+echo "Creating systemd service file..."
+cat > bitcoind.service <<EOF
+[Unit]
+Description=Bitcoin Core Testnet
+After=network.target
+
+[Service]
+User=bitcoin
+Group=bitcoin
+WorkingDirectory=${BITCOIN_DATA_DIR}
+Type=simple
+ExecStart=/opt/bitcoin/current/bin/bitcoind -conf=${BITCOIN_DATA_DIR}/bitcoin.conf
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# === Move config files and set permissions ===
+echo "Setting permissions and moving files..."
+sudo mv bitcoin.conf.tmp "${BITCOIN_DATA_DIR}/bitcoin.conf"
+sudo chown bitcoin:bitcoin "${BITCOIN_DATA_DIR}/bitcoin.conf"
+sudo chown -R bitcoin "${BITCOIN_DATA_DIR}"
+sudo ln -sfn "${BITCOIN_DATA_DIR}" /home/bitcoin/.bitcoin
+sudo chown -h bitcoin:bitcoin /home/bitcoin
+sudo chown -R bitcoin:bitcoin /home/bitcoin
+
+# === Enable and start systemd service ===
+echo "Enabling bitcoind systemd service..."
+sudo mv bitcoind.service /etc/systemd/system/bitcoind.service
+sudo systemctl daemon-reload
+sudo systemctl enable bitcoind
+sudo systemctl start bitcoind
+
+# === Switch to bitcoin user and update PATH ===
+echo "Appending Bitcoin Core to PATH for bitcoin user..."
+sudo su - bitcoin -c 'echo "export PATH=\$PATH:/opt/bitcoin/current/bin" >> ~/.profile'
+
+echo "Bitcoin Core setup complete!"
+echo "Use 'sudo su - bitcoin' then run 'bitcoin-cli -getinfo' to check sync status."
+echo "Or run 'sudo journalctl -fu bitcoind' as root to monitor logs."

--- a/BACON/setup-ord.sh
+++ b/BACON/setup-ord.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Step 1: Update system packages
+echo "Updating system packages..."
+sudo apt update && sudo apt upgrade -y
+
+# Step 2: Install required dependencies
+echo "Installing dependencies..."
+sudo apt install -y curl git build-essential libssl-dev pkg-config
+
+# Step 3: Install Rust
+echo "Installing Rust..."
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source "$HOME/.cargo/env"
+
+# Step 4: Check Rust versions
+rustc --version
+cargo --version
+
+# Step 5: Download and extract ord source code
+echo "Downloading ord 0.22.2..."
+wget https://github.com/ordinals/ord/archive/refs/tags/0.22.2.tar.gz
+tar -xvzf 0.22.2.tar.gz
+cd ord-0.22.2
+
+# Step 6: Install build tools (again, just in case)
+echo "Installing build tools for compiling ord..."
+sudo apt update
+sudo apt install -y build-essential clang cmake gcc g++ make pkg-config libssl-dev
+
+# Step 7: Build ord from source
+echo "Building ord..."
+cargo build --release
+
+# Step 8: Move the binary to /usr/local/bin
+echo "Moving ord binary to /usr/local/bin..."
+sudo mv target/release/ord /usr/local/bin/
+
+# Step 9: Verify ord installation
+ord --version
+
+# Optional: Get the index
+echo "Downloading index file..."
+sudo apt update && sudo apt install transmission-cli -y
+transmission-cli "https://ordstuff.info/indexes/0.22/index-0.22-without-878500.redb.gz.torrent"
+
+# Wait for download to complete manually before continuing
+
+# Optional: Decompress the index file
+echo "Installing pv for decompression progress..."
+sudo apt install -y pv
+pv index-0.22-without-878500.redb.gz | gunzip > index-0.22-without-878500.redb
+
+echo "Setup complete!"


### PR DESCRIPTION
As per the discussion this is the scripts encompassing the commands , used by me to deploy ordinals and mainnet. 

References : https://medium.com/coinmonks/ultimate-guide-to-bitcoin-testnet-fullnode-setup-b83da1bb22e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an automated setup for Bitcoin Core on Linux, simplifying installation, configuration, and service management.
  - Added an automated process to install and verify ord software, streamlining dependency updates, toolchain setup, and software deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->