### PR TITLE
Added Script to fetch all Gsoc orgs

### DIFF
--- a/website/management/commands/fetch_gsoc_orgs.py
+++ b/website/management/commands/fetch_gsoc_orgs.py
@@ -18,70 +18,148 @@ COLOR_RESET = "\033[0m"
 
 logger = logging.getLogger(__name__)
 
-GSoC_API_URL = "https://summerofcode.withgoogle.com/api/program/2025/organizations/"
+# Base API URL for GSoC organizations
+GSOC_API_BASE_URL = "https://summerofcode.withgoogle.com/api/archive/programs/{year}/organizations/"
+
+# Years to fetch (update this list as needed)
+GSOC_YEARS = [2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016]
 
 
 class Command(BaseCommand):
-    help = "Fetches organizations from Google Summer of Code and stores them in the database."
+    help = (
+        "Fetches organizations from Google Summer of Code (current and previous years) and stores them in the database."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--years",
+            nargs="+",
+            type=int,
+            help="Specific years to fetch (e.g., --years 2025 2024 2023). If not specified, all configured years will be fetched.",
+        )
+        parser.add_argument("--current-only", action="store_true", help="Fetch only the current year (2025)")
 
     def handle(self, *args, **kwargs):
-        logger.info(f"{COLOR_BLUE}Fetching organizations from GSoC 2025 API...{COLOR_RESET}")
+        years_to_fetch = kwargs.get("years")
+        current_only = kwargs.get("current_only")
+
+        if current_only:
+            years_to_fetch = [GSOC_YEARS[0]]  # Only fetch the most recent year (2025)
+        elif not years_to_fetch:
+            years_to_fetch = GSOC_YEARS  # Fetch all years if not specified
+
+        total_orgs = 0
+
+        for year in years_to_fetch:
+            orgs_count = self.fetch_organizations_for_year(year)
+            if orgs_count:
+                total_orgs += orgs_count
+
+        logger.info(
+            f"{COLOR_GREEN}Finished fetching organizations! Total: {total_orgs} organizations from {len(years_to_fetch)} years{COLOR_RESET}"
+        )
+
+    def fetch_organizations_for_year(self, year):
+        """Fetch and process organizations for a specific GSoC year."""
+        api_url = GSOC_API_BASE_URL.format(year=year)
+        logger.info(f"{COLOR_BLUE}Fetching organizations from GSoC {year} API...{COLOR_RESET}")
 
         try:
-            response = requests.get(GSoC_API_URL, headers={"User-Agent": "GSOC-Fetcher/1.0"})
+            response = requests.get(api_url, headers={"User-Agent": "GSOC-Fetcher/1.0"})
             response.raise_for_status()
             organizations = response.json()
+
+            logger.info(f"{COLOR_GREEN}Found {len(organizations)} organizations for GSoC {year}{COLOR_RESET}")
+
+            for org_data in organizations:
+                self.process_organization(org_data, year)
+
+            return len(organizations)
+
         except requests.RequestException as e:
-            logger.error(f"{COLOR_RED}Error fetching data from GSoC API: {str(e)}{COLOR_RESET}")
-            return
+            logger.error(f"{COLOR_RED}Error fetching data from GSoC {year} API: {str(e)}{COLOR_RESET}")
+            return 0
 
-        for org_data in organizations:
-            self.process_organization(org_data)
-
-        logger.info(f"{COLOR_GREEN}Finished fetching organizations!{COLOR_RESET}")
-
-    def process_organization(self, org_data):
+    def process_organization(self, org_data, year):
         data = org_data
         slug = slugify(data["slug"])
+        url = data.get("website_url", "")
 
         try:
-            org, created = Organization.objects.update_or_create(
-                slug=slug,
-                defaults={
-                    "name": data["name"],
-                    "description": data.get("description", "")[:500],
-                    "url": data.get("website_url"),
-                    "tagline": data.get("tagline", ""),
-                    "license": data.get("license", ""),
-                    "categories": data.get("categories") or [],
-                    "contributor_guidance_url": data.get("contributor_guidance_url", ""),
-                    "tech_tags": data.get("tech_tags") or [],
-                    "topic_tags": data.get("topic_tags") or [],
-                    "source_code": data.get("source_code", ""),
-                    "ideas_link": data.get("ideas_link", ""),
-                    "is_active": True,
-                },
-            )
+            # First check if an organization with the same URL exists
+            existing_orgs = Organization.objects.filter(url=url) if url else None
 
-            # Handle Logo
-            if data.get("logo_url"):
+            if existing_orgs and existing_orgs.exists():
+                # Organization with same URL already exists, update it instead of creating a new one
+                org = existing_orgs.first()
+                # Update basic info in case it changed
+                org.name = data["name"]
+                org.description = data.get("description", "")[:500]
+                org.tagline = data.get("tagline", "")
+                org.license = data.get("license", "")
+                org.categories = data.get("categories") or []
+                org.contributor_guidance_url = data.get("contributor_guidance_url", "")
+                org.tech_tags = data.get("tech_tags") or []
+                org.topic_tags = data.get("topic_tags") or []
+                org.source_code = data.get("source_code", "")
+                org.ideas_link = data.get("ideas_link", "")
+                org.is_active = True
+                created = False
+                logger.info(f"{COLOR_BLUE}Found existing organization with same URL: {org.name}{COLOR_RESET}")
+            else:
+                # No existing organization with this URL, create a new one
+                org, created = Organization.objects.update_or_create(
+                    slug=slug,
+                    defaults={
+                        "name": data["name"],
+                        "description": data.get("description", "")[:500],
+                        "url": url,
+                        "tagline": data.get("tagline", ""),
+                        "license": data.get("license", ""),
+                        "categories": data.get("categories") or [],
+                        "contributor_guidance_url": data.get("contributor_guidance_url", ""),
+                        "tech_tags": data.get("tech_tags") or [],
+                        "topic_tags": data.get("topic_tags") or [],
+                        "source_code": data.get("source_code", ""),
+                        "ideas_link": data.get("ideas_link", ""),
+                        "is_active": True,
+                    },
+                )
+
+            # Handle Logo - only download if this is a newly created org or it doesn't have a logo yet
+            if data.get("logo_url") and (created or not org.logo):
                 self.download_logo(data["logo_url"], org, slug)
 
             # Handle Tags (tech_tags + topic_tags)
             self.assign_tags(org, data.get("tech_tags", []) + data.get("topic_tags", []))
 
+            # Add year-specific tag
+            year_tag_slug = f"gsoc{str(year)[2:]}"
+            year_tag_name = f"GSoC {year}"
+            year_tag, _ = Tag.objects.get_or_create(slug=year_tag_slug, defaults={"name": year_tag_name})
+            org.tags.add(year_tag)
+
             # Handle Contact Links
             self.assign_contacts(org, data.get("contact_links", []))
 
+            # Add a field to track participation years if it doesn't exist
+            if not hasattr(org, "gsoc_years") or not org.gsoc_years:
+                org.gsoc_years = []
+
+            # Add this year to the organization's participation history if not already there
+            if year not in org.gsoc_years:
+                org.gsoc_years.append(year)
+                org.gsoc_years.sort(reverse=True)  # Most recent years first
+
             org.save()
             status = "Added" if created else "Updated"
-            logger.info(f"{COLOR_GREEN}{status}: {data['name']}{COLOR_RESET}")
+            logger.info(f"{COLOR_GREEN}{status}: {data['name']} (GSoC {year}){COLOR_RESET}")
 
         except Exception as e:
-            logger.error(f"{COLOR_RED}Failed to save {data['name']}: {str(e)}{COLOR_RESET}")
+            logger.error(f"{COLOR_RED}Failed to save {data['name']} (GSoC {year}): {str(e)}{COLOR_RESET}")
 
     def download_logo(self, logo_url, org, slug):
-        """Downloads and saves the organization’s logo."""
+        """Downloads and saves the organization's logo."""
         try:
             response = requests.get(logo_url)
             response.raise_for_status()
@@ -102,9 +180,10 @@ class Command(BaseCommand):
             tag_slug = slugify(tag_name)
             tag, _ = Tag.objects.get_or_create(slug=tag_slug, defaults={"name": tag_name})
             org.tags.add(tag)
-        # also add the tag gsoc25 to all orgs that run this
-        tag, _ = Tag.objects.get_or_create(slug="gsoc25", defaults={"name": "GSoC 2025"})
-        org.tags.add(tag)
+
+        # Add a general GSoC tag
+        gsoc_tag, _ = Tag.objects.get_or_create(slug="gsoc", defaults={"name": "Google Summer of Code"})
+        org.tags.add(gsoc_tag)
 
     def assign_contacts(self, org, social_links):
         social_mapping = {

--- a/website/management/commands/fetch_gsoc_orgs.py
+++ b/website/management/commands/fetch_gsoc_orgs.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 GSOC_API_BASE_URL = "https://summerofcode.withgoogle.com/api/archive/programs/{year}/organizations/"
 
 # Years to fetch (update this list as needed)
-GSOC_YEARS = [2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016]
+GSOC_YEARS = [2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016]
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
Fixes #3264 
![image](https://github.com/user-attachments/assets/bad329a3-6123-4412-8f97-e4d3b6966e72)
You just have to run:
python manage.py fetch_gsoc_orgs --years 2020
if you want to fetch organizations for a specific year.
To fetch organizations for all years, simply run:
python manage.py fetch_gsoc_orgs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for fetching Google Summer of Code (GSoC) organizations data across multiple years.
  - Organizations now display year-specific participation tags and a general GSoC tag.
  - Participation history for each organization is tracked and updated.

- **Bug Fixes**
  - Improved deduplication to update existing organizations by website URL, reducing duplicate entries.

- **Enhancements**
  - Enhanced logging with clearer year context for better traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->