### PR TITLE
fixes bounties/payouts

### DIFF
--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -2766,6 +2766,7 @@ class BountyPayoutsView(ListView):
             try:
                 # Import required models
                 from website.models import GitHubIssue, Repo
+
                 page = 1
                 per_page = 100
                 all_issues = []

--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -2781,7 +2781,8 @@ class BountyPayoutsView(ListView):
                         break
                     page += 1
 
-                issues = self.github_issues_with_bounties("$5", "closed", per_page=100)
+                issues = all_issues
+                count = 0
                 count = 0
 
                 for issue_data in issues:

--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -549,8 +549,6 @@ class Listbounties(TemplateView):
 
             for issue in issues:
                 related_prs = []
-
-                # Only include issues, not PRs in the response
                 if issue.get("pull_request") is None:
                     formatted_issue = {
                         "id": issue.get("id"),
@@ -2729,7 +2727,6 @@ class BountyPayoutsView(ListView):
         encoded_label = label.replace("$", "%24")
         query_params = f"repo:OWASP-BLT/BLT+is:issue+state:{issue_state}+label:{encoded_label}"
         url = f"https://api.github.com/search/issues?q={query_params}&page={page}&per_page={per_page}"
-
         headers = {}
         if settings.GITHUB_TOKEN:
             headers["Authorization"] = f"token {settings.GITHUB_TOKEN}"
@@ -2739,18 +2736,18 @@ class BountyPayoutsView(ListView):
             if response.status_code == 200:
                 data = response.json()
                 issues = data.get("items", [])
-
+                total_count = data.get("total_count", 0)
                 # Cache the results for 30 minutes
                 cache.set(cache_key, issues, 60 * 30)
 
-                return issues
+                return issues, total_count
             else:
                 # Log the error response from GitHub
                 logger.error(f"GitHub API error: {response.status_code} - {response.text[:200]}")
-                return []
+                return [], 0
         except Exception as e:
             logger.error(f"Error fetching GitHub issues: {str(e)}")
-            return []
+            return [], 0
 
     def post(self, request, *args, **kwargs):
         """Handle POST requests for refreshing issues or processing payments"""
@@ -2769,6 +2766,20 @@ class BountyPayoutsView(ListView):
             try:
                 # Import required models
                 from website.models import GitHubIssue, Repo
+                page = 1
+                per_page = 100
+                all_issues = []
+                total_count = None
+                while True:
+                    issues, api_total_count = self.github_issues_with_bounties("$5", "closed", page, per_page)
+                    if total_count is None and api_total_count is not None:
+                        total_count = api_total_count
+                    if not issues:
+                        break
+                    all_issues.extend(issues)
+                    if len(issues) < per_page or len(all_issues) >= total_count:
+                        break
+                    page += 1
 
                 issues = self.github_issues_with_bounties("$5", "closed", per_page=100)
                 count = 0


### PR DESCRIPTION
Modified post function to fetch all pages of GitHub issues with pagination.
Fixes issue where not all bounties were shown on /bounties/payouts/ page as reported in https://github.com/OWASP-BLT/BLT/issues/4031.
Fixes: https://github.com/OWASP-BLT/BLT/issues/4031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved retrieval of closed GitHub issues with bounties by fetching all available pages, ensuring a complete and up-to-date list.
- **Bug Fixes**
  - Enhanced error handling for GitHub API responses to provide more reliable results when issues cannot be fetched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->