### PR TITLE
Fix: Hackathon timezone

### DIFF
--- a/website/templates/hackathons/detail.html
+++ b/website/templates/hackathons/detail.html
@@ -97,11 +97,11 @@
                         <div class="flex flex-col space-y-2">
                             <div class="flex items-center">
                                 <div class="w-24 font-medium text-gray-600">Start:</div>
-                                <div>{{ hackathon.start_time|date:"F j, Y, g:i a" }}</div>
+                                <div>{{ hackathon.start_time|date:"F j, Y, g:i a T" }}</div>
                             </div>
                             <div class="flex items-center">
                                 <div class="w-24 font-medium text-gray-600">End:</div>
-                                <div>{{ hackathon.end_time|date:"F j, Y, g:i a" }}</div>
+                                <div>{{ hackathon.end_time|date:"F j, Y, g:i a T" }}</div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated date formatting on the hackathon detail page to display timezone abbreviations alongside start and end times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->