### PR TITLE
docs: replace deprecated 'poetry shell' with 'poetry env activate'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,8 +104,10 @@ Before you start contributing, you'll need to set up your development environmen
 
    ```bash
    pip install poetry
-   poetry shell
-   poetry install
+   pip install poetry                # requires Poetry ≥ 1.7.0  
+   poetry env use python3.11         # create or select the env  
+   eval $(poetry env activate)       # prints and runs the activation command  
+   poetry install 
    ```
 
 3. Set up the application:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ Before you start contributing, you'll need to set up your development environmen
 
    ```bash
    pip install poetry
-   poetry shell
+   poetry env activate
    poetry install
    ```
 


### PR DESCRIPTION
### What I did

Updated `contributing.md` to replace the deprecated `poetry shell` command with the recommended `poetry env activate` as per Poetry 2.1 documentation (https://python-poetry.org/docs/managing-environments/#bash-csh-zsh). 

### Why

Poetry 2.1+ no longer includes the `shell` command by default. Using `poetry env activate` reflects current best practices and avoids confusion for contributors.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the contributing guide with a more detailed and explicit sequence for setting up and activating the Poetry-managed Python virtual environment, including specifying the Python version and Poetry version requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->