### PR TITLE
[fix] Add missing dark mode classes to management commands page

### DIFF
--- a/website/templates/management_commands.html
+++ b/website/templates/management_commands.html
@@ -159,7 +159,7 @@
                     </thead>
                     <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                         {% for command in commands %}
-                            <tr class="hover:bg-gray-50 cursor-pointer"
+                            <tr class="hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer"
                                 data-command="{{ command.name }}">
                                 <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
                                     <div class="flex items-center">
@@ -231,10 +231,10 @@
                                         </div>
                                     {% endif %}
                                 </td>
-                                <td class="px-6 py-4 text-sm text-gray-500">
+                                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
                                     {% if command.file_modified %}
                                         <div class="flex flex-col">
-                                            <span class="text-xs text-gray-600">Modified: {{ command.file_modified|timesince }} ago</span>
+                                            <span class="text-xs text-gray-600 dark:text-gray-400">Modified: {{ command.file_modified|timesince }} ago</span>
                                             {% if command.github_url %}
                                                 <a href="{{ command.github_url }}"
                                                    target="_blank"
@@ -299,30 +299,30 @@
                                 </td>
                             </tr>
                             {% if command.arguments or command.output %}
-                                <tr class="hidden bg-gray-50" id="args-{{ command.name }}">
+                                <tr class="hidden bg-gray-50 dark:bg-gray-700" id="args-{{ command.name }}">
                                     <td colspan="9" class="px-6 py-4">
-                                        <div class="bg-gray-50 p-4 rounded-lg space-y-4">
+                                        <div class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg space-y-4">
                                             {% if command.arguments %}
                                                 <div>
-                                                    <h3 class="text-sm font-medium text-gray-700 mb-2">Command Arguments</h3>
+                                                    <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 mb-2">Command Arguments</h3>
                                                     <table class="min-w-full divide-y divide-gray-200">
                                                         <thead>
                                                             <tr>
-                                                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Argument</th>
-                                                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Flags</th>
-                                                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
-                                                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-                                                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Required</th>
-                                                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Default</th>
+                                                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Argument</th>
+                                                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Flags</th>
+                                                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Description</th>
+                                                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Type</th>
+                                                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Required</th>
+                                                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Default</th>
                                                             </tr>
                                                         </thead>
                                                         <tbody>
                                                             {% for arg in command.arguments %}
                                                                 <tr>
-                                                                    <td class="px-4 py-2 whitespace-nowrap text-sm font-medium text-gray-900">{{ arg.name }}</td>
-                                                                    <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">{{ arg.flags }}</td>
-                                                                    <td class="px-4 py-2 text-sm text-gray-500">{{ arg.help }}</td>
-                                                                    <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">{{ arg.type }}</td>
+                                                                    <td class="px-4 py-2 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{{ arg.name }}</td>
+                                                                    <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ arg.flags }}</td>
+                                                                    <td class="px-4 py-2 text-sm text-gray-500 dark:text-gray-400">{{ arg.help }}</td>
+                                                                    <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ arg.type }}</td>
                                                                     <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">
                                                                         {% if arg.required %}
                                                                             <span class="text-red-500">Yes</span>


### PR DESCRIPTION
Description:
The Management Commands page (/status/commands/) had several missing Tailwind CSS dark mode variant classes, causing text and backgrounds to be invisible or incorrectly styled when dark mode was active.

Changes Made:
Added dark:text-gray-300 to the "Command Arguments" heading
Added dark:text-gray-400 to all th elements in the Command Arguments table
Added dark:text-gray-100 and dark:text-gray-400 to td elements in the arguments tbody
Added dark:bg-gray-700 to the expanded row background and inner container
Added dark:hover:bg-gray-700 to prevent row turning white on hover in dark mode
Added dark:text-gray-400 to File Info and Modified date columns

Screenshots:
- Before (text invisible in dark mode):
<img width="1366" height="723" alt="Screenshot 2026-05-03 201905" src="https://github.com/user-attachments/assets/2e3c2664-8986-4195-ab0f-34eceb5479bb" />
- After (text visible in dark mode):
<img width="1365" height="725" alt="image" src="https://github.com/user-attachments/assets/014ec734-69af-48b4-ba63-492f3577f7ed" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode styling for the management commands interface with improved visibility and consistency throughout the section, including better contrast and hover effects in dark theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->