### PR TITLE
Fix bounty payout endpoint handling

### DIFF
--- a/.github/workflows/bounty-payout.yml
+++ b/.github/workflows/bounty-payout.yml
@@ -94,19 +94,23 @@ jobs:
 
       - name: Send bounty data to BLT
         if: steps.check-issues.outputs['has-bounty'] == 'true'
-        continue-on-error: true
         env:
           ISSUE_NUMBER: ${{ steps.check-issues.outputs.issue-number }}
           BOUNTY_AMOUNT: ${{ steps.check-issues.outputs.bounty-amount }}
           CONTRIBUTOR_USERNAME: ${{ steps.check-issues.outputs.contributor-username }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BLT_API_TOKEN: ${{ secrets.BLT_API_TOKEN }}
-          API_BASE_URL: ${{ secrets.API_BASE_URL || 'https://owasp.org' }}
+          API_BASE_URL: ${{ secrets.API_BASE_URL || 'https://owaspblt.org' }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0 https://github.com/actions/github-script/commit/f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const response = await fetch(`${process.env.API_BASE_URL}/bounty_payout/`, {
+            if (!process.env.BLT_API_TOKEN) {
+              throw new Error('BLT_API_TOKEN secret is required to process bounty payouts');
+            }
+
+            const apiBaseUrl = process.env.API_BASE_URL.replace(/\/+$/, '');
+            const response = await fetch(`${apiBaseUrl}/bounty_payout/`, {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',

--- a/website/tests/test_bounty.py
+++ b/website/tests/test_bounty.py
@@ -183,6 +183,31 @@ class BountyPayoutTestCase(TestCase):
 
     @override_settings(BLT_API_TOKEN="test_token_12345")
     @patch.dict(os.environ, {"BLT_API_TOKEN": "test_token_12345"})
+    def test_bounty_payout_rejects_non_positive_amount(self):
+        """Test that zero or negative bounty payments are rejected."""
+        payload = {
+            "issue_number": 123,
+            "repo": "TestRepo",
+            "owner": "TestOrg",
+            "contributor_username": "testuser",
+            "pr_number": 456,
+            "bounty_amount": 0,
+        }
+
+        response = self.client.post(
+            "/bounty_payout/",
+            data=json.dumps(payload),
+            content_type="application/json",
+            HTTP_X_BLT_API_TOKEN=self.api_token,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        response_data = response.json()
+        self.assertEqual(response_data["status"], "error")
+        self.assertIn("greater than zero", response_data["message"])
+
+    @override_settings(BLT_API_TOKEN="test_token_12345")
+    @patch.dict(os.environ, {"BLT_API_TOKEN": "test_token_12345"})
     def test_bounty_payout_issue_not_found(self):
         """Test that non-existent issue is handled."""
         payload = {

--- a/website/views/bounty.py
+++ b/website/views/bounty.py
@@ -54,6 +54,10 @@ def bounty_payout(request):
             logger.warning("Invalid numeric fields in request")
             return JsonResponse({"status": "error", "message": "Invalid numeric fields"}, status=400)
 
+        if bounty_amount <= 0:
+            logger.warning("Invalid bounty amount in request")
+            return JsonResponse({"status": "error", "message": "Bounty amount must be greater than zero"}, status=400)
+
         repo_name = data["repo"]
         owner_name = data["owner"]
         contributor_username = data["contributor_username"]


### PR DESCRIPTION
## Summary
- default bounty payout requests to the BLT app domain instead of owasp.org
- fail the workflow when the payout token is missing or the payout API rejects the request
- normalize trailing slashes in API_BASE_URL before calling /bounty_payout/
- reject zero or negative bounty amounts in the payout API

Fixes #3941

## Testing
- python -m py_compile website\\views\\bounty.py website\\tests\\test_bounty.py

Note: I could not run the Django test suite locally because Django is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bounty payout endpoint now validates and rejects requests with zero or negative bounty amounts, returning HTTP 400 with clear error messaging

* **Tests**
  * Added test coverage for bounty amount validation

* **Chores**
  * Enhanced workflow error handling and API base URL configuration

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OWASP-BLT/BLT/pull/6380)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->